### PR TITLE
Design adjustments and fixes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -214,7 +214,6 @@ h1, h2, h3 {
 
 .moon-calendar .calendar-day.today {
   background: hsl(var(--primary) / 0.2);
-  border: 1px solid hsl(var(--primary) / 0.5);
 }
 
 .moon-mini {

--- a/app/components/distance_bar_component.html.erb
+++ b/app/components/distance_bar_component.html.erb
@@ -6,7 +6,7 @@
     <div
       class="absolute top-1/2 -translate-y-1/2 w-3 h-3 bg-white border-2
                 border-primary rounded-full"
-      style="left: <%= percentage %>%"></div>
+      style="left: clamp(0px, calc(<%= percentage %>% - 6px), calc(100% - 12px));"></div>
   </div>
   <div class="flex justify-between text-xs text-muted-foreground mt-2">
     <span>

--- a/app/views/home/_current_moon.html.erb
+++ b/app/views/home/_current_moon.html.erb
@@ -24,7 +24,7 @@
         <span class="text-muted-foreground">
           <%= t ".titles.rise" %>
         </span>
-        <span class="font-medium">
+        <span class="font-mono">
           <%= nillable_datetime(
             moon.rts.rising_time,
             utc_offset: observer.utc_offset,
@@ -36,7 +36,7 @@
         <span class="text-muted-foreground">
           <%= t ".titles.transit" %>
         </span>
-        <span class="font-medium">
+        <span class="font-mono">
           <%= nillable_datetime(
             moon.rts.transit_time,
             utc_offset: observer.utc_offset,
@@ -48,7 +48,7 @@
         <span class="text-muted-foreground">
           <%= t ".titles.set" %>
         </span>
-        <span class="font-medium">
+        <span class="font-mono">
           <%= nillable_datetime(
             moon.rts.setting_time,
             utc_offset: observer.utc_offset,

--- a/app/views/home/_deep_sky_objects.html.erb
+++ b/app/views/home/_deep_sky_objects.html.erb
@@ -6,7 +6,8 @@
     <% messier_object_positions.each do |messier_object_position| %>
       <div class="rounded-lg border bg-card text-card-foreground shadow-sm
         cosmic-card flex flex-col p-4">
-        <div class="flex items-start justify-between mb-3">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between
+          mb-3 gap-3">
           <div class="flex items-center gap-3">
             <span class="text-4xl">
               <%= t(
@@ -36,87 +37,83 @@
           <div class="inline-flex items-center rounded-full border px-2.5 py-0.5
             text-xs font-semibold transition-colors focus:outline-none
             focus:ring-2 focus:ring-ring focus:ring-offset-2
-            border-transparent">
+            border-transparent self-start">
             <%= messier_object_position.messier_object.visible_with %>
           </div>
         </div>
 
-        <div class="grid grid-cols-3 gap-2 text-center my-3">
-          <div>
-            <div class="text-xs text-muted-foreground">
-              <%= t ".magnitude" %>
-            </div>
-            <div class="font-semibold text-foreground">
-              <%= messier_object_position.messier_object.magnitude %>
-            </div>
-          </div>
-          <div>
-            <div class="text-xs text-muted-foreground">
-              <%= t ".type" %>
-            </div>
-            <div class="font-semibold text-foreground truncate">
-              <%= t(
-                "messier.types.#{messier_object_position.messier_object.type}.name"
-              ) %>
-            </div>
-          </div>
-          <div>
-            <div class="text-xs text-muted-foreground">
-              <%= t ".size" %>
-            </div>
-            <div class="font-semibold text-foreground">
-              <%= messier_object_position.messier_object.size %>
-            </div>
-          </div>
-        </div>
-
-        <div class="flex justify-between items-center text-sm border-t
-          border-border/20 pt-2 mt-auto">
-          <div class="text-center text-muted-foreground">
-            <div class="font-mono text-foreground">
-              <%= nillable_datetime(
-                messier_object_position.rts.rising_time,
-                utc_offset: observer.utc_offset,
-                format: :hm
-              ) %>
-            </div>
-            <div class="text-xs">
-              <%= t ".rise" %>
-            </div>
-          </div>
-          <div class="text-center text-sky-400 dark:text-sky-300">
-            <div class="font-mono font-bold">
-              <%= nillable_datetime(
-                messier_object_position.rts.transit_time,
-                utc_offset: observer.utc_offset,
-                format: :hm
-              ) %>
-            </div>
-            <div class="text-xs font-semibold">
-              <%= t ".transit" %>
-            </div>
-          </div>
-          <div class="text-center text-muted-foreground">
-            <div class="font-mono text-foreground">
-              <%= nillable_datetime(
-                messier_object_position.rts.setting_time,
-                utc_offset: observer.utc_offset,
-                format: :hm
-              ) %>
-            </div>
-            <div class="text-xs">
-              <%= t ".set" %>
-            </div>
-          </div>
-        </div>
-
-        <details class="text-xs mt-3">
+        <details class="text-xs mt-1">
           <summary class="cursor-pointer text-muted-foreground
-            hover:text-foreground transition-colors">
+            hover:text-foreground mb-2">
             <%= t ".details" %>
           </summary>
-          <div class="space-y-1 text-muted-foreground pt-2 pl-2 border-l
-            border-border/20 ml-1 mt-1">
+          <div class="space-y-3 text-muted-foreground">
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-2 text-center mb-4">
+              <div class="sm:order-1">
+                <div class="text-xs text-muted-foreground">
+                  <%= t ".magnitude" %>
+                </div>
+                <div class="font-semibold text-foreground">
+                  <%= messier_object_position.messier_object.magnitude %>
+                </div>
+              </div>
+              <div class="sm:order-3">
+                <div class="text-xs text-muted-foreground">
+                  <%= t ".size" %>
+                </div>
+                <div class="font-semibold text-foreground">
+                  <%= messier_object_position.messier_object.size %>
+                </div>
+              </div>
+              <div class="col-span-2 sm:col-span-1 sm:order-2">
+                <div class="text-xs text-muted-foreground">
+                  <%= t ".type" %>
+                </div>
+                <div class="font-semibold text-foreground">
+                  <%= t(
+                    "messier.types.#{messier_object_position.messier_object.type}.name"
+                  ) %>
+                </div>
+              </div>
+            </div>
+            <div class="flex justify-between items-center text-sm mb-4">
+              <div class="text-center text-muted-foreground">
+                <div class="font-mono text-foreground">
+                  <%= nillable_datetime(
+                    messier_object_position.rts.rising_time,
+                    utc_offset: observer.utc_offset,
+                    format: :hm
+                  ) %>
+                </div>
+                <div class="text-xs">
+                  <%= t ".rise" %>
+                </div>
+              </div>
+              <div class="text-center text-sky-400 dark:text-sky-300">
+                <div class="font-mono font-bold">
+                  <%= nillable_datetime(
+                    messier_object_position.rts.transit_time,
+                    utc_offset: observer.utc_offset,
+                    format: :hm
+                  ) %>
+                </div>
+                <div class="text-xs font-semibold">
+                  <%= t ".transit" %>
+                </div>
+              </div>
+              <div class="text-center text-muted-foreground">
+                <div class="font-mono text-foreground">
+                  <%= nillable_datetime(
+                    messier_object_position.rts.setting_time,
+                    utc_offset: observer.utc_offset,
+                    format: :hm
+                  ) %>
+                </div>
+                <div class="text-xs">
+                  <%= t ".set" %>
+                </div>
+              </div>
+            </div>
             <div class="flex justify-between">
               <span>
                 <%= t ".titles.right_ascension" %>

--- a/app/views/home/_planets_tonight.html.erb
+++ b/app/views/home/_planets_tonight.html.erb
@@ -11,8 +11,7 @@
             <h3 class="text-xl font-bold"><%= planet.class.planet_name %></h3>
           </div>
           <div class="inline-flex items-center rounded-full border px-2.5 py-0.5
-            text-xs font-semibold transition-colors focus:outline-none
-            focus:ring-2 focus:ring-ring focus:ring-offset-2 glow-accent
+            text-xs font-semibold
             <%= planet.visibility.visible? ? "border-transparent bg-primary text-primary-foreground" : "border-transparent" %>">
             <%= planet.visibility.visible? ? t(".visibility.visible") : t(".visibility.not_visible") %>
           </div>
@@ -20,7 +19,7 @@
         <div class="space-y-2 text-sm text-muted-foreground">
           <div class="flex justify-between">
             <span><%= t ".titles.magnitude" %></span>
-            <span class="text-foreground font-medium">
+            <span class="text-foreground font-mono">
               <%= format_number planet.magnitude, precision: 2 %>
             </span>
           </div>
@@ -32,7 +31,7 @@
           </div>
           <div class="flex justify-between">
             <span><%= t ".titles.rise" %></span>
-            <span class="text-foreground font-medium">
+            <span class="text-foreground font-mono">
               <%= nillable_datetime(
                 planet.rts.rising_time,
                 utc_offset: observer.utc_offset,
@@ -42,7 +41,7 @@
           </div>
           <div class="flex justify-between">
             <span><%= t ".titles.set" %></span>
-            <span class="text-foreground font-medium">
+            <span class="text-foreground font-mono">
               <%= nillable_datetime(
                 planet.rts.setting_time,
                 utc_offset: observer.utc_offset,
@@ -52,7 +51,7 @@
           </div>
           <div class="flex justify-between">
             <span><%= t ".titles.distance" %></span>
-            <span class="text-foreground font-medium">
+            <span class="text-foreground font-mono">
               <%= format_number(
                 planet.distance_from_earth.au,
                 unit: :au,

--- a/app/views/home/_sun_moon_times.html.erb
+++ b/app/views/home/_sun_moon_times.html.erb
@@ -15,7 +15,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.civil_twilight" %>
           </span>
-          <span class="font-medium">
+          <span class="font-mono">
             <%= nillable_datetime(
               twilight_events.morning_civil_twilight_time,
               utc_offset: observer.utc_offset,
@@ -27,7 +27,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.sunrise" %>
           </span>
-          <span class="font-medium text-yellow-400">
+          <span class="font-mono text-yellow-400">
             <%= nillable_datetime(
               sun.rts.rising_time,
               utc_offset: observer.utc_offset,
@@ -39,7 +39,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.sunset" %>
           </span>
-          <span class="font-medium text-orange-400">
+          <span class="font-mono text-orange-400">
             <%= nillable_datetime(
               sun.rts.setting_time,
               utc_offset: observer.utc_offset,
@@ -51,7 +51,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.civil_twilight_end" %>
           </span>
-          <span class="font-medium">
+          <span class="font-mono">
             <%= nillable_datetime(
               twilight_events.evening_civil_twilight_time,
               utc_offset: observer.utc_offset,
@@ -61,6 +61,8 @@
         </div>
       </div>
     </div>
+
+    <%= link_to t(".sun_link"), sun_path, class: "link text-sm" %>
 
     <div class="shrink-0 bg-border h-[1px] w-full my-4"></div>
 
@@ -76,7 +78,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.moonrise" %>
           </span>
-          <span class="font-medium text-blue-300">
+          <span class="font-mono text-blue-300">
             <%= nillable_datetime(
               moon.rts.rising_time,
               utc_offset: observer.utc_offset,
@@ -88,7 +90,7 @@
           <span class="text-muted-foreground">
             <%= t ".titles.moonset" %>
           </span>
-          <span class="font-medium text-blue-300">
+          <span class="font-mono text-blue-300">
             <%= nillable_datetime(
               moon.rts.setting_time,
               utc_offset: observer.utc_offset,

--- a/app/views/home/_tonight_sky.html.erb
+++ b/app/views/home/_tonight_sky.html.erb
@@ -7,7 +7,7 @@
       <span class="text-muted-foreground">
         <%= t ".titles.astronomical_twilight" %>
       </span>
-      <span class="font-medium">
+      <span class="font-mono">
         <%= nillable_datetime(
           twilight_events.evening_astronomical_twilight_time,
           utc_offset: observer.utc_offset,

--- a/app/views/moon/_distances.html.erb
+++ b/app/views/moon/_distances.html.erb
@@ -30,24 +30,18 @@
           <span class="text-muted-foreground">
             <%= t ".next_perigee" %>
           </span>
-          <span class="font-medium">
-            <%= nillable_datetime(
-              next_perigee.instant.to_time,
-              utc_offset: observer.utc_offset,
-              format: :short
-            ) %>
+          <span class="font-mono text-right">
+            <%= l next_perigee.instant.to_time.to_date, format: :full_month_short %>
+            <%= l next_perigee.instant.to_time, format: :utc_hm %>
           </span>
         </div>
         <div class="flex justify-between">
           <span class="text-muted-foreground">
             <%= t ".next_apogee" %>
           </span>
-          <span class="font-medium">
-            <%= nillable_datetime(
-              next_apogee.instant.to_time,
-              utc_offset: observer.utc_offset,
-              format: :short
-            ) %>
+          <span class="font-mono text-right">
+            <%= l next_apogee.instant.to_time.to_date, format: :full_month_short %>
+            <%= l next_apogee.instant.to_time, format: :utc_hm %>
           </span>
         </div>
       </div>

--- a/app/views/moon/_today.html.erb
+++ b/app/views/moon/_today.html.erb
@@ -9,7 +9,7 @@
           <%= t ".moonrise" %>
         </span>
         <div class="text-right">
-          <div class="font-semibold">
+          <div class="font-mono">
             <%= nillable_datetime(
               moon.rts.rising_time,
               utc_offset: observer.utc_offset,
@@ -35,7 +35,7 @@
           <%= t ".transit" %>
         </span>
         <div class="text-right">
-          <div class="font-semibold">
+          <div class="font-mono">
             <%= nillable_datetime(
               moon.rts.transit_time,
               utc_offset: observer.utc_offset,
@@ -61,7 +61,7 @@
           <%= t ".moonset" %>
         </span>
         <div class="text-right">
-          <div class="font-semibold">
+          <div class="font-mono">
             <%= nillable_datetime(
               moon.rts.setting_time,
               utc_offset: observer.utc_offset,

--- a/app/views/sun/_distances.html.erb
+++ b/app/views/sun/_distances.html.erb
@@ -30,7 +30,7 @@
           <span class="text-muted-foreground">
             <%= t ".next_perihelion" %>
           </span>
-          <span class="font-medium">
+          <span class="font-mono text-right">
             <%= l next_perihelion.instant.to_time.to_date, format: :full_month_short %>
             <%= l next_perihelion.instant.to_time, format: :utc_hm %>
           </span>
@@ -39,7 +39,7 @@
           <span class="text-muted-foreground">
             <%= t ".next_aphelion" %>
           </span>
-          <span class="font-medium">
+          <span class="font-mono text-right">
             <%= l next_aphelion.instant.to_time.to_date, format: :full_month_short %>
             <%= l next_aphelion.instant.to_time, format: :utc_hm %>
           </span>

--- a/app/views/sun/_hero.html.erb
+++ b/app/views/sun/_hero.html.erb
@@ -159,11 +159,12 @@
         <div class="text-xs text-muted-foreground mb-1">
           <%= t ".distance" %>
         </div>
-        <div class="text-xl font-semibold">
-          <%= format_number(
-            sun.distance_from_earth.km,
-            unit: :km,
-            precision: 0
+        <div class="text-base font-semibold sm:text-lg md:text-xl">
+          <%= t(
+            ".distance_value_html",
+            distance: sun.distance_from_earth.km.to_i / 1_000_000,
+            unit: t("units.kilometer.symbol"),
+            sup: 6
           ) %>
         </div>
         <div class="text-xs text-muted-foreground">

--- a/app/views/sun/_seasons.html.erb
+++ b/app/views/sun/_seasons.html.erb
@@ -3,8 +3,8 @@
     <%= t ".title" %>
   </h3>
   <div class="space-y-3">
-    <% upcoming_seasons.each_with_index do |season, i| %>
-      <div class="season-item <%= "current" if i.zero? %>">
+    <% upcoming_seasons.each do |season| %>
+      <div class="season-item">
         <div class="flex items-center gap-3">
           <div class="flex-1">
             <div class="font-semibold">
@@ -17,11 +17,6 @@
               <%= l season[:time], format: :utc_hm %>
             </div>
           </div>
-          <% if i.zero? %>
-            <span class="text-xs bg-primary/20 text-primary px-2 py-1 rounded">
-              <%= t ".next" %>
-            </span>
-          <% end %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en:
         not_visible: Not Visible
         visible: Visible
     sun_moon_times:
+      sun_link: See Sun details
       title: "Sun & Moon Times"
       titles:
         civil_twilight: "Civil Twilight:"
@@ -640,6 +641,7 @@ en:
       current_altitude: Current Altitude
       day_length: Day Length
       distance: Distance
+      distance_value_html: "%{distance} × 10<sup>%{sup}</sup>%{unit}"
       light_travel: Light Travel
       solar_noon: Solar Noon
       to_earth: to Earth
@@ -661,7 +663,7 @@ en:
       title: 🛠️ Practical Info
     seasons:
       next: Next
-      title: 🍂 Seasons
+      title: 🍂 Next Seasons
     show:
       title: Sun
     sky_position:


### PR DESCRIPTION
After great feedback from @jeanelie, here are the items that got changed or fixes:

- removed border layer on non-clickable items
- fixed the body icon on the distance bar component
- used mono font on times and other measurements for consistency and ease of reading
- fixed deep sky object layout on smaller screens
- hid by default most of the astronomical information from deep sky objects
- removed unnecessary classes for planets
- added link for Sun page
- added consistency between Moon and Sun periapsis/apoapsis times
- converted Sun distance to scientific notation to reduce characters