### PR TITLE
Make it easier to enable location features

### DIFF
--- a/app/controllers/cookie_consent_controller.rb
+++ b/app/controllers/cookie_consent_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class CookieConsentController < ApplicationController
+  def new
+    render layout: false
+  end
+
   def create
     cookies.signed[:cookie_consent] =
       {value: "true", expires: 1.year.from_now}

--- a/app/javascript/controllers/cookie_consent_modal_controller.js
+++ b/app/javascript/controllers/cookie_consent_modal_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect () {
+    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
+    document.addEventListener('keydown', this.boundCloseOnEscape)
+  }
+
+  disconnect () {
+    document.removeEventListener('keydown', this.boundCloseOnEscape)
+  }
+
+  close () {
+    const modalFrame = document.getElementById('cookie_consent_modal')
+    if (modalFrame) {
+      modalFrame.innerHTML = ''
+    }
+  }
+
+  closeOnEscape (event) {
+    if (event.key === 'Escape') {
+      this.close()
+    }
+  }
+}

--- a/app/views/cookie_consent/new.html.erb
+++ b/app/views/cookie_consent/new.html.erb
@@ -1,0 +1,75 @@
+<turbo-frame id="cookie_consent_modal">
+  <div data-controller="cookie-consent-modal">
+    <div
+      class="fixed inset-0 bg-black/60 z-40"
+      data-action="click->cookie-consent-modal#close"
+    ></div>
+
+    <div class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2
+      rounded-lg border bg-white dark:bg-gray-900 text-card-foreground shadow-sm
+      z-50 w-full max-w-md p-6">
+      <div class="flex items-start justify-between mb-4">
+        <h2 class="text-xl font-bold text-cosmic">
+          <%= t "shared.cookie_consent_modal.title" %>
+        </h2>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200
+            cursor-pointer"
+          data-action="click->cookie-consent-modal#close"
+          title="<%= t("shared.cookie_consent_modal.close") %>"
+        >
+          <svg
+            class="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            ></path>
+          </svg>
+        </button>
+      </div>
+      
+      <div class="mb-6">
+        <p class="text-sm text-gray-700 dark:text-gray-300 mb-4">
+          <%= t "shared.cookie_consent_modal.description" %>
+        </p>
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          <%= t "shared.cookie_consent_modal.location_feature_description" %>
+          <%= link_to(
+            t("shared.cookie_consent_modal.learn_more"),
+            privacy_policy_path,
+            target: "_blank",
+            class: "text-blue-600 dark:text-blue-400 hover:underline"
+          ) %>
+        </p>
+      </div>
+      
+      <div class="flex flex-col sm:flex-row gap-3">
+        <button
+          type="button"
+          class="rounded-md border border-input bg-transparent
+            px-12 py-2 hover:bg-accent hover:text-accent-foreground
+            cursor-pointer"
+          data-action="click->cookie-consent-modal#close"
+        >
+          <%= t("shared.cookie_consent_modal.decline") %>
+        </button>
+        <%= button_to(
+          t("shared.cookie_consent_modal.accept_cookies"),
+          cookie_consent_path,
+          method: :post,
+          data: { turbo_frame: "_top" },
+          form: { class: "w-full sm:flex-1" },
+          class: "cursor-pointer rounded-md bg-primary text-primary-foreground
+            py-2 hover:bg-primary/90 w-full"
+        ) %>
+      </div>
+    </div>
+  </div>
+</turbo-frame>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
 </main>
 
 <turbo-frame id="location_modal"></turbo-frame>
+<turbo-frame id="cookie_consent_modal"></turbo-frame>
 <% unless cookie_consent_chosen? %>
   <%= render "shared/cookie_consent_banner" %>
 <% end %>

--- a/app/views/shared/_location_selector.html.erb
+++ b/app/views/shared/_location_selector.html.erb
@@ -11,15 +11,15 @@
       <%= render "shared/icons/location" %>
     </a>
   <% else %>
-    <span
-      aria-label="<%= t ".location_modal.label" %>"
-      class="text-gray-800 dark:text-gray-100 cursor-not-allowed"
-      title="<%= t(".location_modal.title_no_cookie_conset") %>"
+    <a
+      href="<%= new_cookie_consent_path %>"
+      data-turbo-frame="cookie_consent_modal"
+      aria-label="<%= t ".cookie_consent_modal.label" %>"
+      class="text-gray-800 dark:text-gray-100 hover:text-gray-600
+              dark:hover:text-gray-300 transition-colors cursor-pointer"
+      title="<%= t(".cookie_consent_modal.title") %>"
     >
-      <%= render(
-        "shared/icons/location",
-        class: "text-gray-400 dark:text-gray-500"
-      ) %>
-    </span>
+      <%= render "shared/icons/location", disabled: true %>
+    </a>
   <% end %>
 </div>

--- a/app/views/shared/icons/_location.html.erb
+++ b/app/views/shared/icons/_location.html.erb
@@ -8,4 +8,15 @@
         0c.5-.6 5.4-6.55 5.4-9.4 0-3.15-2.55-5.7-5.7-5.7zm0 7.7a2 2 0 110-4 2
         2 0 010 4z"
     clip-rule="evenodd" />
+  <% if local_assigns[:disabled] %>
+    <line
+      x1="3"
+      y1="3"
+      x2="17"
+      y2="17"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+    />
+  <% end %>
 </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -594,6 +594,17 @@ en:
       description: We use cookies to remember your stargazing location for
         personalised sky data and observations.
       learn_more: Learn more
+    cookie_consent_modal:
+      title: Accept Cookies
+      close: Close
+      description: To use location-based features, we need your consent to store
+        cookies that remember your location preferences.
+      location_feature_description: Accepting cookies will enable personalised
+        astronomical data like accurate sunrise/sunset times, moon phases, and
+        planet visibility for your location.
+      learn_more: Learn more
+      accept_cookies: Accept Cookies
+      decline: Not Now
     footer:
       enable_cookies: Enable Cookies
       made_with_love_html: "Made with &hearts; by %{author_link}
@@ -603,7 +614,9 @@ en:
       location_modal:
         label: Set your location
         title: Set your location preferences
-        title_no_cookie_conset: Accept cookies to set location preferences
+      cookie_consent_modal:
+        label: Accept cookies for location features
+        title: Accept cookies for location features
     navigation:
       moon: Moon
       sun: Sun

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   resource :privacy_policy, only: :show, controller: :privacy_policy
   resource :cookie_consent,
-    only: [:create, :destroy],
+    only: [:create, :destroy, :new],
     controller: :cookie_consent
 
   get "up" => "rails/health#show", :as => :rails_health_check


### PR DESCRIPTION
Before, if the cookies weren't accepted, the user would have to go to the bottom of the page, click "Enable cookies" link in order to access the ability to set their own location and time zone (UTC offset).

Now, if the cookies are not accepted, the user can still click the location icon (which now appears "disabled"), which will open a cookie consent modal. This should make it easier to change one's mind about cookies and enjoy the app.

Thanks @jaredlt for the suggestion.