### PR TITLE
Bump astronoby to v0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "astronoby", github: "rhannequin/astronoby"
+gem "astronoby"
 gem "bootsnap", require: false
 gem "bugsnag"
 gem "importmap-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/rhannequin/astronoby.git
-  revision: 42c1f89fe254aa3c85e8049df9dde6963f6932fd
-  specs:
-    astronoby (0.8.0)
-      ephem (~> 0.3)
-      matrix (~> 0.4.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,6 +75,9 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
+    astronoby (0.9.0)
+      ephem (~> 0.3)
+      matrix (~> 0.4.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.5.0)
@@ -417,7 +412,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.3)
-    zlib (3.2.1)
+    zlib (3.2.2)
 
 PLATFORMS
   aarch64-linux
@@ -431,7 +426,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  astronoby!
+  astronoby
   bootsnap
   brakeman
   bugsnag

--- a/app/models/sub_solar_observer.rb
+++ b/app/models/sub_solar_observer.rb
@@ -16,7 +16,7 @@ class SubSolarObserver
   end
 
   def observer
-    sidereal_time = Astronoby::GreenwichSiderealTime
+    sidereal_time = Astronoby::GreenwichApparentSiderealTime
       .from_utc(@time.utc)
       .time
     longitude = @sun_right_ascension -


### PR DESCRIPTION
We are now using official versions of Astronoby instead of `main` branch.
v0.9.0 of Astronoby introduces `Astronoby::GreenwichApparentSiderealTime`, which is relevant for Caelus when calculating the sub-solar point accurately.