### PR TITLE
Add light-weight analytics with GoatCounter

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,5 +79,8 @@
 <% unless cookie_consent_chosen? %>
   <%= render "shared/cookie_consent_banner" %>
 <% end %>
+<script
+  data-goatcounter="https://rhannequin.goatcounter.com/count"
+  async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
[GoatCounter](https://www.goatcounter.com) is a light-weight [open source](https://github.com/arp242/goatcounter) web analytics platform.