### PR TITLE
Fix CSP violation for GoatCounter script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,8 +79,11 @@
 <% unless cookie_consent_chosen? %>
   <%= render "shared/cookie_consent_banner" %>
 <% end %>
-<script
-  data-goatcounter="https://rhannequin.goatcounter.com/count"
-  async src="//gc.zgo.at/count.js"></script>
+<%= tag.script(
+  src: "https://gc.zgo.at/count.js",
+  async: true,
+  data: { goatcounter: "https://rhannequin.goatcounter.com/count" },
+  nonce: content_security_policy_nonce
+) %>
 </body>
 </html>


### PR DESCRIPTION
Use Rails tag helper with nonce: true instead of a raw script tag so the CSP nonce is automatically applied.