### PR TITLE
Fix cache key strategy to prevent redundant recomputation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,8 @@ class ApplicationController < ActionController::Base
   helper_method :cookie_consent_given?,
     :cookie_consent_chosen?,
     :observer_cache_key,
+    :observer_daily_cache_key,
+    :observer_yearly_cache_key,
     :observer_end_of_day,
     :observer_end_of_year
 
@@ -67,9 +69,18 @@ class ApplicationController < ActionController::Base
   end
 
   def observer_cache_key
-    "#{@observer.latitude.degrees.round(3)}/" \
-      "#{@observer.longitude.degrees.round(3)}/" \
-      "#{@observer.time_zone.tzinfo.name}/#{@time.to_date}"
+    @observer_cache_key ||=
+      "#{@observer.latitude.degrees.round(3)}/" \
+        "#{@observer.longitude.degrees.round(3)}/" \
+        "#{@observer.time_zone.tzinfo.name}"
+  end
+
+  def observer_daily_cache_key
+    @observer_daily_cache_key ||= "#{observer_cache_key}/#{@time.to_date}"
+  end
+
+  def observer_yearly_cache_key
+    @observer_yearly_cache_key ||= "#{observer_cache_key}/#{@time.year}"
   end
 
   def observer_end_of_day

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
   def index
     @planets = Rails.cache.fetch(
-      "planets/#{observer_cache_key}/#{@time.to_date}",
+      "planets/#{observer_daily_cache_key}",
       expires_at: observer_end_of_day
     ) do
       [
@@ -19,19 +19,22 @@ class HomeController < ApplicationController
       ]
     end
 
-    @sun = Rails.cache.fetch("sun/#{observer_cache_key}", expires_in: 1.hour) do
+    @sun = Rails.cache.fetch(
+      "sun/#{observer_daily_cache_key}",
+      expires_in: 1.hour
+    ) do
       Sun.new(observer: @observer, time: @time)
     end
 
     @moon = Rails.cache.fetch(
-      "moon/#{observer_cache_key}",
+      "moon/#{observer_daily_cache_key}",
       expires_in: 1.hour
     ) do
       Moon.new(observer: @observer, time: @time)
     end
 
     @twilight_events = Rails.cache.fetch(
-      "twilight_events/#{observer_cache_key}/#{@time.to_date}",
+      "twilight_events/#{observer_daily_cache_key}",
       expires_at: observer_end_of_day
     ) do
       Astronoby::TwilightCalculator.new(
@@ -44,7 +47,7 @@ class HomeController < ApplicationController
     end
 
     @next_twilight_events = Rails.cache.fetch(
-      "next_twilight_events/#{observer_cache_key}/#{@time.to_date}",
+      "next_twilight_events/#{observer_daily_cache_key}",
       expires_at: observer_end_of_day
     ) do
       Astronoby::TwilightCalculator.new(
@@ -54,7 +57,7 @@ class HomeController < ApplicationController
     end
 
     @messier_object_positions = Rails.cache.fetch(
-      "messier_object_positions/#{observer_cache_key}/#{@time.to_date}",
+      "messier_object_positions/#{observer_daily_cache_key}",
       expires_at: observer_end_of_day
     ) do
       MessierCatalog

--- a/app/controllers/sun_controller.rb
+++ b/app/controllers/sun_controller.rb
@@ -13,7 +13,7 @@ class SunController < ApplicationController
     @sun = Sun.new(observer: @observer, time: @time)
     @yesterday_sun = Sun.new(observer: @observer, time: @time - 1.day)
     @yearly_elevation = Rails.cache.fetch(
-      "sun_elevation/#{observer_cache_key}",
+      "sun_elevation/#{observer_yearly_cache_key}",
       expires_at: observer_end_of_year
     ) do
       YearlyElevation.new(


### PR DESCRIPTION
Split observer_cache_key into three variants:
- observer_cache_key: base key (location + timezone, no date)
- observer_daily_cache_key: includes date for daily caches
- observer_yearly_cache_key: includes year for yearly caches

The main fix is for YearlyElevation  which was using a cache key containing the daily date, causing it to recompute every day instead of being cached for the entire year. Also removes redundant date duplication in `HomeController` cache keys.