### PR TITLE
Pre-filter Messier objects by magnitude before computing positions

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -59,10 +59,9 @@ class HomeController < ApplicationController
     ) do
       MessierCatalog
         .all
+        .sort_by(&:magnitude)
+        .first(MAXIMUM_DEEP_SKY_OBJECTS)
         .map { |obj| obj.at(@time, observer: @observer, use_ephem: true) }
-        .max(MAXIMUM_DEEP_SKY_OBJECTS) do |a, b|
-          b.messier_object.magnitude <=> a.messier_object.magnitude
-        end
     end
   end
 


### PR DESCRIPTION
Sort catalog by magnitude and take top 10 before calling `.at()`, avoiding 10 unnecessary ephemeris position calculations on cache miss.