### PR TITLE
Memoize `spk` and `extremum_calculator` in Sun/Moon controllers

### DIFF
--- a/app/controllers/moon_controller.rb
+++ b/app/controllers/moon_controller.rb
@@ -49,7 +49,7 @@ class MoonController < ApplicationController
   end
 
   def extremum_calculator
-    Astronoby::ExtremumCalculator.new(
+    @extremum_calculator ||= Astronoby::ExtremumCalculator.new(
       body: Moon.planet_class,
       primary_body: Earth.planet_class,
       ephem: SPK.for_time(@time)

--- a/app/controllers/sun_controller.rb
+++ b/app/controllers/sun_controller.rb
@@ -46,7 +46,7 @@ class SunController < ApplicationController
   private
 
   def extremum_calculator
-    Astronoby::ExtremumCalculator.new(
+    @extremum_calculator ||= Astronoby::ExtremumCalculator.new(
       body: Earth.planet_class,
       primary_body: Sun.planet_class,
       ephem: spk
@@ -82,6 +82,6 @@ class SunController < ApplicationController
   end
 
   def spk
-    SPK.for_time(@time)
+    @spk ||= SPK.for_time(@time)
   end
 end


### PR DESCRIPTION
Avoid redundant object creation when these methods are called multiple times within a single request.