### PR TITLE
Enable YJIT in production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,14 @@ RUN apt-get update -qq && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Set production environment variables and enable jemalloc for reduced memory usage and latency.
+# Set production environment variables, enable jemalloc for reduced memory usage
+# and latency, and enable YJIT for improved Ruby execution performance.
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development" \
-    LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+    LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
+    RUBY_YJIT_ENABLE="1"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build


### PR DESCRIPTION
Ruby 3.4.4 ships with YJIT, a lightweight JIT, compiler that improves execution performance. Setting `RUBY_YJIT_ENABLE=1` activates it alongside the existing jemalloc memory optimization.