### PR TITLE
Allow resetting to real-time after choosing a custom datetime

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :cookie_consent_given?,
     :cookie_consent_chosen?,
+    :custom_time?,
     :observer_cache_key,
     :observer_daily_cache_key,
     :observer_yearly_cache_key,
@@ -97,5 +98,9 @@ class ApplicationController < ActionController::Base
 
   def cookie_consent_chosen?
     cookies.signed[:cookie_consent].present?
+  end
+
+  def custom_time?
+    cookies.signed[:time].present?
   end
 end

--- a/app/controllers/time_controller.rb
+++ b/app/controllers/time_controller.rb
@@ -17,6 +17,12 @@ class TimeController < ApplicationController
     redirect_back(fallback_location: root_path)
   end
 
+  def destroy
+    cookies.delete(:time) if cookie_consent_given?
+
+    redirect_back(fallback_location: root_path)
+  end
+
   private
 
   def valid_time?(time)

--- a/app/views/time/edit.html.erb
+++ b/app/views/time/edit.html.erb
@@ -79,6 +79,26 @@
           ) %>
         </div>
       <% end %>
+
+      <% if custom_time? %>
+        <%= form_with(
+          url: time_path,
+          method: :delete,
+          data: { turbo_frame: "_top" }
+        ) do %>
+          <div class="mt-4 pt-4 border-t">
+            <p class="text-sm text-muted-foreground mb-2">
+              <%= t ".reset.description" %>
+            </p>
+            <%= submit_tag(
+              t(".reset.submit"),
+              class: "cursor-pointer rounded-md border border-input
+                bg-transparent px-4 py-2 hover:bg-accent
+                hover:text-accent-foreground"
+            ) %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </turbo-frame>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -726,6 +726,9 @@ en:
         cancel: Cancel
         submit: Save
         time: Date & Time
+      reset:
+        description: A custom date and time is set. Reset to follow real-time again.
+        submit: Reset to real-time
       title: Set Date & Time
     formats:
       full: "%B %d, %Y %H:%M:%S"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root "home#index"
 
   resource :location, only: [:edit, :update], controller: :location
-  resource :time, only: [:edit, :update], controller: :time
+  resource :time, only: [:edit, :update, :destroy], controller: :time
 
   resource :moon, only: [:show], controller: :moon
   resource :sun, only: [:show], controller: :sun

--- a/spec/requests/time_spec.rb
+++ b/spec/requests/time_spec.rb
@@ -90,4 +90,45 @@ RSpec.describe TimeController, type: :request do
       end
     end
   end
+
+  describe "DELETE time" do
+    context "when cookie consent is given" do
+      it "clears the stored time so it follows real-time again" do
+        post cookie_consent_path
+        patch(time_path, params: {time: "2025-12-01T20:49:51"})
+
+        delete time_path
+        jar = response.request.cookie_jar
+
+        expect(jar.signed[:time]).to be_nil
+      end
+
+      it "redirects to the root path when no referer" do
+        post cookie_consent_path
+
+        delete time_path
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "redirects back to the referring page" do
+        post cookie_consent_path
+
+        delete(time_path, headers: {"HTTP_REFERER" => moon_path})
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(moon_path)
+      end
+    end
+
+    context "when cookie consent is not given" do
+      it "redirects back without changing anything" do
+        delete(time_path, headers: {"HTTP_REFERER" => sun_path})
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(sun_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Before, nce a specific datetime was selected, the cookie kept the site pinned to that moment with no way back to live, auto-updating data.

Now, users can reset time back to real-time if they selected a specific date and time before.

Closes #96