### PR TITLE
Implement fragment caching for Moon page

### DIFF
--- a/app/controllers/moon_controller.rb
+++ b/app/controllers/moon_controller.rb
@@ -11,14 +11,34 @@ class MoonController < ApplicationController
 
   def show
     @moon = Moon.new(observer: @observer, time: @time)
-    @next_apogee = extremum_calculator
-      .apoapsis_events_between(@time, @time + EXTREMUM_LOOKAHEAD)
-      .first
-    @next_perigee = extremum_calculator
-      .periapsis_events_between(@time, @time + EXTREMUM_LOOKAHEAD)
-      .first
-    @upcoming_phases = upcoming_phases
-    @week = week_of_moons
+
+    @next_apogee = Rails.cache.fetch(
+      "moon_next_apogee/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) do
+      extremum_calculator
+        .apoapsis_events_between(@time, @time + EXTREMUM_LOOKAHEAD)
+        .first
+    end
+
+    @next_perigee = Rails.cache.fetch(
+      "moon_next_perigee/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) do
+      extremum_calculator
+        .periapsis_events_between(@time, @time + EXTREMUM_LOOKAHEAD)
+        .first
+    end
+
+    @upcoming_phases = Rails.cache.fetch(
+      "moon_upcoming_phases/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) { upcoming_phases }
+
+    @week = Rails.cache.fetch(
+      "moon_week/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) { week_of_moons }
 
     track_page_view("moon")
   end

--- a/app/views/moon/show.html.erb
+++ b/app/views/moon/show.html.erb
@@ -17,8 +17,18 @@
   </div>
 
   <div class="space-y-6">
-    <%= render "upcoming_phases", upcoming_phases: @upcoming_phases %>
-    <%= render "this_week", week: @week %>
+    <%= cache(
+      "moon_upcoming_phases/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) do %>
+      <%= render "upcoming_phases", upcoming_phases: @upcoming_phases %>
+    <% end %>
+    <%= cache(
+      "moon_this_week/#{observer_daily_cache_key}",
+      expires_at: observer_end_of_day
+    ) do %>
+      <%= render "this_week", week: @week %>
+    <% end %>
   </div>
 
   <div class="space-y-6">


### PR DESCRIPTION
The Moon page was missing fragment caching in multiple areas. This will increase this page's performance on reload.