### PR TITLE
Bump astronoby to v0.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,9 @@ GEM
       logger
       rack (>= 2.0.0)
     ast (2.4.3)
-    astronoby (0.9.0)
-      ephem (~> 0.3)
+    astronoby (0.10.0)
+      ephem (~> 0.5)
+      iers (~> 0.1)
       matrix (~> 0.4.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
@@ -119,9 +120,8 @@ GEM
       railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
-    ephem (0.4.1)
+    ephem (0.5.0)
       minitar (~> 0.12)
-      numo-narray (~> 0.9.2.1)
       zlib (~> 3.2)
     erb (6.0.4)
     erubi (1.13.1)
@@ -139,6 +139,7 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    iers (0.1.0)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -210,7 +211,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    numo-narray (0.9.2.1)
     ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -422,7 +422,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.8.2)
-    zlib (3.2.2)
+    zlib (3.2.3)
 
 PLATFORMS
   aarch64-linux

--- a/app/jobs/refresh_iers_data_job.rb
+++ b/app/jobs/refresh_iers_data_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class RefreshIersDataJob < ApplicationJob
+  class RefreshError < StandardError; end
+
+  retry_on RefreshError, wait: :polynomially_longer, attempts: 3
+
+  def perform
+    result = IERS::Data.update!
+
+    unless result.success?
+      details = result.errors
+        .map { |source, error| "#{source}: #{error.message}" }
+        .join("; ")
+      raise RefreshError, "IERS data refresh failed (#{details})"
+    end
+
+    IERS::Data.clear_loaded!
+  end
+end

--- a/app/views/sun/_practical_info.html.erb
+++ b/app/views/sun/_practical_info.html.erb
@@ -56,7 +56,7 @@
       </div>
       <div class="bg-background/50 rounded p-2">
         <div class="font-mono font-semibold">
-          <%= duration_to_human(sun.equation_of_time) %>
+          <%= duration_to_human(sun.equation_of_time.seconds) %>
         </div>
       </div>
     </div>

--- a/config/initializers/astronoby.rb
+++ b/config/initializers/astronoby.rb
@@ -8,6 +8,10 @@ IERS.configure do |config|
   config.cache_dir = Rails.root.join("storage/iers")
 end
 
+# Parse the IERS finals data at boot so the first request doesn't pay the
+# one-time lazy-parse cost.
+Rails.application.config.after_initialize { IERS::Data.finals_entries }
+
 class SPK
   include Singleton
 

--- a/config/initializers/astronoby.rb
+++ b/config/initializers/astronoby.rb
@@ -5,7 +5,7 @@ require "singleton"
 Astronoby.configuration.cache_enabled = true
 
 IERS.configure do |config|
-  config.cache_dir = Rails.root.join("storage", "iers")
+  config.cache_dir = Rails.root.join("storage/iers")
 end
 
 class SPK

--- a/config/initializers/astronoby.rb
+++ b/config/initializers/astronoby.rb
@@ -4,6 +4,10 @@ require "singleton"
 
 Astronoby.configuration.cache_enabled = true
 
+IERS.configure do |config|
+  config.cache_dir = Rails.root.join("storage", "iers")
+end
+
 class SPK
   include Singleton
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  refresh_iers_data:
+    command: "IERS::Data.update!; IERS::Data.clear_loaded!"
+    schedule: every day at 4am

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -14,5 +14,5 @@ production:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
   refresh_iers_data:
-    command: "IERS::Data.update!; IERS::Data.clear_loaded!"
+    class: RefreshIersDataJob
     schedule: every day at 4am

--- a/spec/jobs/refresh_iers_data_job_spec.rb
+++ b/spec/jobs/refresh_iers_data_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RefreshIersDataJob, type: :job do
+  it "clears loaded data when the update succeeds" do
+    result = IERS::UpdateResult.new(
+      updated_files: %i[finals leap_seconds],
+      errors: {}
+    )
+    allow(IERS::Data).to receive(:update!).and_return(result)
+    allow(IERS::Data).to receive(:clear_loaded!)
+
+    described_class.perform_now
+
+    expect(IERS::Data).to have_received(:clear_loaded!)
+  end
+
+  it "raises when a source fails to download so the failure is visible" do
+    error = IERS::DownloadError.new("connection refused")
+    result = IERS::UpdateResult.new(
+      updated_files: [:leap_seconds],
+      errors: {finals: error}
+    )
+    allow(IERS::Data).to receive(:update!).and_return(result)
+    allow(IERS::Data).to receive(:clear_loaded!)
+
+    expect {
+      described_class.new.perform
+    }.to raise_error(
+      described_class::RefreshError,
+      /finals: connection refused/
+    )
+    expect(IERS::Data).not_to have_received(:clear_loaded!)
+  end
+end


### PR DESCRIPTION
[Astronoby](https://github.com/rhannequin/astronoby) v0.10.0 is out and will allow new features in Caelus. First, let's update the dependency to benefit from better performance and better accuracy.

- Bump `astronoby` to v0.10.0
- Adapt to the breaking change (`equation_of_time` now returns a `Duration`)
- Persist the IERS cache on the mounted `storage/` volume instead of the container's ephemeral `~/.cache/iers`, so downloaded data remains after deploys
- Add `RefreshIersDataJob` + a daily recurring task to refresh IERS data
- Warm the IERS finals data at boot so the first request doesn't pay the one-time parse cost
