### PR TITLE
Fix time travel rejecting times without seconds

### DIFF
--- a/app/controllers/time_controller.rb
+++ b/app/controllers/time_controller.rb
@@ -34,8 +34,8 @@ class TimeController < ApplicationController
   def valid_time?(time)
     return false if time.blank?
 
-    parsed_time = Time.iso8601(time)
-    parsed_time.in?(TIME_RANGE)
+    parsed_time = Time.zone.parse(time)
+    parsed_time&.utc&.in?(TIME_RANGE) || false
   rescue ArgumentError, TypeError
     false
   end

--- a/spec/requests/time_spec.rb
+++ b/spec/requests/time_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe TimeController, type: :request do
         expect(jar.signed[:time]).to eq("2025-12-01T19:49:51Z")
       end
 
+      it "accepts the datetime-local format without seconds" do
+        post cookie_consent_path
+
+        patch(
+          time_path,
+          params: {time: "2026-06-30T00:00"}
+        )
+        jar = response.request.cookie_jar
+
+        expect(jar.signed[:time]).to eq("2026-06-29T22:00:00Z")
+      end
+
       it "ignores invalid time value" do
         post cookie_consent_path
 


### PR DESCRIPTION
This now accepts `datetime-local` times without seconds in `TimeController`.