### PR TITLE
Extract shared spk helper into ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,4 +105,8 @@ class ApplicationController < ActionController::Base
   def custom_time?
     cookies.signed[:time].present?
   end
+
+  def spk
+    @spk ||= SPK.for_time(@time)
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -49,10 +49,4 @@ class HomeController < ApplicationController
 
     track_page_view("home")
   end
-
-  private
-
-  def spk
-    SPK.for_time(@time)
-  end
 end

--- a/app/controllers/moon_controller.rb
+++ b/app/controllers/moon_controller.rb
@@ -74,7 +74,7 @@ class MoonController < ApplicationController
     @extremum_calculator ||= Astronoby::ExtremumCalculator.new(
       body: Moon.planet_class,
       primary_body: Earth.planet_class,
-      ephem: SPK.for_time(@time)
+      ephem: spk
     )
   end
 end

--- a/app/controllers/sun_controller.rb
+++ b/app/controllers/sun_controller.rb
@@ -49,8 +49,4 @@ class SunController < ApplicationController
       ephem: spk
     )
   end
-
-  def spk
-    @spk ||= SPK.for_time(@time)
-  end
 end


### PR DESCRIPTION
Before, the SPK ephemeris lookup for the request time was duplicated across `SunController` and `HomeController`, each with different memoization.

Now, this is moved into a single memoized helper up in `ApplicationController`.