### PR TITLE
Extract cookie consent guard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,4 +109,8 @@ class ApplicationController < ActionController::Base
   def spk
     @spk ||= SPK.for_time(@time)
   end
+
+  def require_cookie_consent
+    redirect_back(fallback_location: root_path) unless cookie_consent_given?
+  end
 end

--- a/app/controllers/location_controller.rb
+++ b/app/controllers/location_controller.rb
@@ -10,6 +10,8 @@ class LocationController < ApplicationController
     .to_set
     .freeze
 
+  before_action :require_cookie_consent, only: :update
+
   def edit
     @latitude = @observer.latitude.degrees.round(4)
     @longitude = @observer.longitude.degrees.round(4)
@@ -17,8 +19,6 @@ class LocationController < ApplicationController
   end
 
   def update
-    return redirect_back(fallback_location: root_path) unless cookie_consent_given?
-
     changed = false
 
     if valid_latitude?(params[:latitude]) && valid_longitude?(params[:longitude])

--- a/app/controllers/time_controller.rb
+++ b/app/controllers/time_controller.rb
@@ -3,12 +3,12 @@
 class TimeController < ApplicationController
   TIME_RANGE = Time.utc(1900, 1, 1)...Time.utc(2100, 1, 1)
 
+  before_action :require_cookie_consent, only: :update
+
   def edit
   end
 
   def update
-    return redirect_back(fallback_location: root_path) unless cookie_consent_given?
-
     if valid_time?(params[:time])
       cookies.permanent.signed[:time] =
         Time.zone.parse(params[:time]).utc.iso8601


### PR DESCRIPTION
Before, `TimeController#update` and `LocationController#update` both opened with an identical inline consent check.

Now, we added a shared `require_cookie_consent` `before_action` in `ApplicationController`.