### PR TITLE
Extract shared base modal Stimulus controller

### DIFF
--- a/app/javascript/controllers/cookie_consent_modal_controller.js
+++ b/app/javascript/controllers/cookie_consent_modal_controller.js
@@ -1,25 +1,3 @@
-import { Controller } from '@hotwired/stimulus'
+import Modal from 'controllers/modal'
 
-export default class extends Controller {
-  connect () {
-    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
-    document.addEventListener('keydown', this.boundCloseOnEscape)
-  }
-
-  disconnect () {
-    document.removeEventListener('keydown', this.boundCloseOnEscape)
-  }
-
-  close () {
-    const modalFrame = document.getElementById('cookie_consent_modal')
-    if (modalFrame) {
-      modalFrame.innerHTML = ''
-    }
-  }
-
-  closeOnEscape (event) {
-    if (event.key === 'Escape') {
-      this.close()
-    }
-  }
-}
+export default class extends Modal {}

--- a/app/javascript/controllers/location_controller.js
+++ b/app/javascript/controllers/location_controller.js
@@ -1,11 +1,10 @@
-import { Controller } from '@hotwired/stimulus'
+import Modal from 'controllers/modal'
 
-export default class extends Controller {
+export default class extends Modal {
   static targets = ['lat', 'lng', 'detectBtn', 'timeZone']
 
   connect () {
-    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
-    document.addEventListener('keydown', this.boundCloseOnEscape)
+    super.connect()
 
     if (this.hasDetectBtnTarget) {
       this.originalButtonText = this.detectBtnTarget.textContent
@@ -13,7 +12,7 @@ export default class extends Controller {
   }
 
   disconnect () {
-    document.removeEventListener('keydown', this.boundCloseOnEscape)
+    super.disconnect()
     this.stopLoadingAnimation()
   }
 
@@ -96,24 +95,6 @@ export default class extends Controller {
           .resolvedOptions()
           .timeZone
       } catch (_error) {}
-    }
-  }
-
-  close () {
-    const modalFrame = document.getElementById('location_modal')
-    if (modalFrame) {
-      modalFrame.innerHTML = ''
-    }
-  }
-
-  cancel (event) {
-    event.preventDefault()
-    this.close()
-  }
-
-  closeOnEscape (event) {
-    if (event.key === 'Escape') {
-      this.close()
     }
   }
 

--- a/app/javascript/controllers/modal.js
+++ b/app/javascript/controllers/modal.js
@@ -1,0 +1,33 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Base controller for turbo-frame modals. Closes the modal by clearing its
+// enclosing turbo-frame and on the Escape key. Subclasses that override
+// connect/disconnect must call super.
+export default class extends Controller {
+  connect () {
+    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
+    document.addEventListener('keydown', this.boundCloseOnEscape)
+  }
+
+  disconnect () {
+    document.removeEventListener('keydown', this.boundCloseOnEscape)
+  }
+
+  close () {
+    const modalFrame = this.element.closest('turbo-frame')
+    if (modalFrame) {
+      modalFrame.innerHTML = ''
+    }
+  }
+
+  cancel (event) {
+    event.preventDefault()
+    this.close()
+  }
+
+  closeOnEscape (event) {
+    if (event.key === 'Escape') {
+      this.close()
+    }
+  }
+}

--- a/app/javascript/controllers/time_controller.js
+++ b/app/javascript/controllers/time_controller.js
@@ -1,34 +1,8 @@
-import { Controller } from '@hotwired/stimulus'
+import Modal from 'controllers/modal'
 
-export default class extends Controller {
+export default class extends Modal {
   static targets = ['timeField']
   static values = { timezone: String }
-  connect () {
-    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
-    document.addEventListener('keydown', this.boundCloseOnEscape)
-  }
-
-  disconnect () {
-    document.removeEventListener('keydown', this.boundCloseOnEscape)
-  }
-
-  close () {
-    const modalFrame = document.getElementById('time_modal')
-    if (modalFrame) {
-      modalFrame.innerHTML = ''
-    }
-  }
-
-  cancel (event) {
-    event.preventDefault()
-    this.close()
-  }
-
-  closeOnEscape (event) {
-    if (event.key === 'Escape') {
-      this.close()
-    }
-  }
 
   setCurrentTime (event) {
     event.preventDefault()


### PR DESCRIPTION
Before, the cookie consent, location and time controllers each reimplemented the same `connect`/`disconnect`/`close`/`closeOnEscape` modal logic, differing only by a hardcoded turbo-frame id.

Now, we have a base `Modal` controller that closes by clearing its enclosing turbo-frame, removing the id coupling.