### PR TITLE
Use the exposed lunar eclipse geometry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "appsignal"
-gem "astronoby"
+gem "astronoby", github: "rhannequin/astronoby", branch: "main"
 gem "bootsnap", require: false
 gem "importmap-rails"
 gem "kamal", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/rhannequin/astronoby.git
+  revision: 85e9b3866d58beb1a9ac02865ba0d908ccfb44db
+  branch: main
+  specs:
+    astronoby (0.10.0)
+      ephem (~> 0.5)
+      iers (~> 0.1)
+      matrix (~> 0.4.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,10 +91,6 @@ GEM
       logger
       rack (>= 2.0.0)
     ast (2.4.3)
-    astronoby (0.10.0)
-      ephem (~> 0.5)
-      iers (~> 0.1)
-      matrix (~> 0.4.2)
     base64 (0.3.0)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
@@ -139,7 +145,7 @@ GEM
       activesupport (>= 6.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    iers (0.1.0)
+    iers (0.2.0)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -439,7 +445,7 @@ PLATFORMS
 
 DEPENDENCIES
   appsignal
-  astronoby
+  astronoby!
   bootsnap
   brakeman
   bundler-audit

--- a/app/components/lunar_eclipse_disc_component.html.erb
+++ b/app/components/lunar_eclipse_disc_component.html.erb
@@ -35,7 +35,11 @@
     </radialGradient>
 
     <clipPath id="<%= moon_clip_id %>">
-      <circle cx="0" cy="<%= round(moon_y) %>" r="<%= moon_radius %>"/>
+      <circle
+        cx="<%= round(moon_x) %>"
+        cy="<%= round(moon_y) %>"
+        r="<%= moon_radius %>"
+      />
     </clipPath>
   </defs>
 
@@ -75,19 +79,19 @@
       />
 
       <line
-        x1="<%= round(-half_width) %>"
-        y1="<%= round(moon_y) %>"
-        x2="<%= round(half_width) %>"
-        y2="<%= round(moon_y) %>"
+        x1="<%= round(path_ends.first.first) %>"
+        y1="<%= round(path_ends.first.last) %>"
+        x2="<%= round(path_ends.last.first) %>"
+        y2="<%= round(path_ends.last.last) %>"
         stroke="<%= ghost_color %>"
         stroke-opacity="0.5"
         stroke-width="<%= stroke_width %>"
         stroke-dasharray="0.25 0.2"
       />
-      <% contact_offsets.each do |offset| %>
+      <% ghost_positions.each do |x, y| %>
         <circle
-          cx="<%= round(offset) %>"
-          cy="<%= round(moon_y) %>"
+          cx="<%= round(x) %>"
+          cy="<%= round(y) %>"
           r="<%= moon_radius %>"
           fill="none"
           stroke="<%= ghost_color %>"
@@ -98,7 +102,7 @@
     <% end %>
 
     <circle
-      cx="0"
+      cx="<%= round(moon_x) %>"
       cy="<%= round(moon_y) %>"
       r="<%= moon_radius %>"
       fill="<%= moon_color %>"
@@ -127,7 +131,7 @@
       />
     </g>
     <circle
-      cx="0"
+      cx="<%= round(moon_x) %>"
       cy="<%= round(moon_y) %>"
       r="<%= moon_radius %>"
       fill="none"

--- a/app/components/lunar_eclipse_disc_component.rb
+++ b/app/components/lunar_eclipse_disc_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LunarEclipseDiscComponent < ViewComponent::Base
-  MOON_RADIUS_KM = 1737.4
+  MOON_RADIUS_KM = Astronoby::Constants::IAU_MOON_RADIUS_IN_METERS / 1000.0
 
   MOON_COLOR = "#d4d0c3"
   MOON_EDGE_COLOR = "#f2eee2"
@@ -15,6 +15,8 @@ class LunarEclipseDiscComponent < ViewComponent::Base
   MOON_RADIUS = 1
   MOON_FRAME = 1.25
   LINE_WIDTH = 1.6
+
+  EXTERNAL_TANGENCY_OFFSET = 180
 
   def initialize(lunar_eclipse:, size: 160, detailed: false)
     @lunar_eclipse = lunar_eclipse
@@ -41,68 +43,114 @@ class LunarEclipseDiscComponent < ViewComponent::Base
 
   def view_box
     if detailed?
-      [-half_width, -half_height, view_box_width, view_box_height]
+      [bounds.first, bounds.second, view_box_width, view_box_height]
     else
-      [-MOON_FRAME, moon_y - MOON_FRAME, view_box_width, view_box_height]
+      [
+        moon_x - MOON_FRAME,
+        moon_y - MOON_FRAME,
+        view_box_width,
+        view_box_height
+      ]
     end.map { |value| round(value) }.join(" ")
   end
 
   def view_box_width
-    detailed? ? half_width * 2 : MOON_FRAME * 2
+    detailed? ? bounds.third - bounds.first : MOON_FRAME * 2
   end
 
   def view_box_height
-    detailed? ? half_height * 2 : MOON_FRAME * 2
+    detailed? ? bounds.fourth - bounds.second : MOON_FRAME * 2
   end
 
-  def half_height
-    @half_height ||=
-      [penumbra_radius, axis_distance + MOON_RADIUS].max + MARGIN
-  end
+  # The Moon leaves the shadow further along its path than it entered, so the
+  # figure is framed on what it actually draws rather than on the shadow.
+  def bounds
+    @bounds ||= begin
+      discs = ([moon_position] + ghost_positions).map do |x, y|
+        [
+          x - MOON_RADIUS,
+          y - MOON_RADIUS,
+          x + MOON_RADIUS,
+          y + MOON_RADIUS
+        ]
+      end
+      boxes = discs << [
+        -penumbra_radius,
+        -penumbra_radius,
+        penumbra_radius,
+        penumbra_radius
+      ]
 
-  def half_width
-    @half_width ||= [
-      half_height,
-      contact_offsets.max.to_f + MOON_RADIUS + MARGIN
-    ].max
-  end
-
-  def axis_distance
-    @axis_distance ||= lunar_eclipse.shadow_axis_distance.km / MOON_RADIUS_KM
+      [
+        boxes.map(&:first).min - MARGIN,
+        boxes.map(&:second).min - MARGIN,
+        boxes.map(&:third).max + MARGIN,
+        boxes.map(&:fourth).max + MARGIN
+      ]
+    end
   end
 
   def umbra_radius
-    @umbra_radius ||= shadow_radius(lunar_eclipse.umbral_magnitude)
+    @umbra_radius ||= in_moon_radii(geometry.umbra_radius)
   end
 
   def penumbra_radius
-    @penumbra_radius ||= shadow_radius(lunar_eclipse.penumbral_magnitude)
+    @penumbra_radius ||= in_moon_radii(geometry.penumbra_radius)
   end
 
-  def shadow_radius(magnitude)
-    [2 * magnitude * MOON_RADIUS - MOON_RADIUS + axis_distance, 0].max
+  def geometry
+    lunar_eclipse.geometry
+  end
+
+  def in_moon_radii(distance)
+    distance.km / MOON_RADIUS_KM
+  end
+
+  def moon_position
+    @moon_position ||= position_of(geometry)
+  end
+
+  def moon_x
+    moon_position.first
   end
 
   def moon_y
-    @moon_y ||=
-      lunar_eclipse.gamma.negative? ? axis_distance : -axis_distance
+    moon_position.last
   end
 
-  def contact_offsets
+  def position_of(contact_geometry, external_tangency: false)
+    degrees = contact_geometry.position_angle.degrees
+    degrees += EXTERNAL_TANGENCY_OFFSET if external_tangency
+    angle = Astronoby::Angle.from_degrees(degrees)
+    distance = in_moon_radii(contact_geometry.axis_distance)
+
+    [distance * angle.sin, -distance * angle.cos]
+  end
+
+  def contact_geometries
     return [] unless detailed?
 
-    @contact_offsets ||= [
-      penumbra_radius + MOON_RADIUS,
-      (umbra_radius + MOON_RADIUS if lunar_eclipse.partial),
-      (umbra_radius - MOON_RADIUS if lunar_eclipse.total)
+    umbral = lunar_eclipse.partial
+    totality = lunar_eclipse.total
+
+    [
+      [lunar_eclipse.penumbral.starting_geometry, true],
+      [lunar_eclipse.penumbral.ending_geometry, true],
+      ([umbral.starting_geometry, true] if umbral),
+      ([umbral.ending_geometry, true] if umbral),
+      ([totality.starting_geometry, false] if totality),
+      ([totality.ending_geometry, false] if totality)
     ].compact
-      .filter_map { |distance| half_chord(distance) }
-      .flat_map { |offset| [-offset, offset] }
   end
 
-  def half_chord(distance)
-    squared = distance**2 - axis_distance**2
-    Math.sqrt(squared) if squared.positive?
+  def ghost_positions
+    @ghost_positions ||= contact_geometries.map do |contact, external|
+      position_of(contact, external_tangency: external)
+    end
+  end
+
+  def path_ends
+    ghost_positions.first(2)
   end
 
   def round(value)
@@ -173,7 +221,10 @@ class LunarEclipseDiscComponent < ViewComponent::Base
     t(
       "lunar_eclipses.disc.description",
       kind: t("lunar_eclipses.kinds.#{lunar_eclipse.kind}.name"),
-      distance: helpers.format_number(axis_distance, precision: 2),
+      distance: helpers.format_number(
+        in_moon_radii(geometry.axis_distance),
+        precision: 2
+      ),
       direction: t("lunar_eclipses.disc.#{hemisphere}"),
       umbral: umbral_immersion,
       penumbral: helpers.number_to_percentage(

--- a/app/controllers/lunar_eclipses_controller.rb
+++ b/app/controllers/lunar_eclipses_controller.rb
@@ -3,6 +3,10 @@
 class LunarEclipsesController < ApplicationController
   SUPPORTED_YEARS = (1900..2100)
 
+  ASTRONOBY_BUILD = File.basename(
+    Gem.loaded_specs.fetch("astronoby").full_gem_path
+  )
+
   helper_method :lunar_eclipse_cache_key
 
   def index
@@ -43,7 +47,7 @@ class LunarEclipsesController < ApplicationController
   end
 
   def lunar_eclipse_cache_key(scope)
-    "lunar_eclipses/#{Astronoby::VERSION}/#{scope}"
+    "lunar_eclipses/#{ASTRONOBY_BUILD}/#{scope}"
   end
 
   def selected_year

--- a/app/helpers/lunar_eclipse_helper.rb
+++ b/app/helpers/lunar_eclipse_helper.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
 module LunarEclipseHelper
+  Contact = Struct.new(:key, :time, :position_angle)
+
   def lunar_eclipse_contacts(lunar_eclipse)
+    penumbral = lunar_eclipse.penumbral
     umbral = lunar_eclipse.partial
     totality = lunar_eclipse.total
 
     [
-      [:p1, lunar_eclipse.penumbral.starting_instant],
-      ([:u1, umbral.starting_instant] if umbral),
-      ([:u2, totality.starting_instant] if totality),
-      [:greatest, lunar_eclipse.instant],
-      ([:u3, totality.ending_instant] if totality),
-      ([:u4, umbral.ending_instant] if umbral),
-      [:p4, lunar_eclipse.penumbral.ending_instant]
-    ].compact.map { |key, instant| [key, instant.to_time] }
+      [:p1, penumbral.starting_instant, penumbral.starting_geometry],
+      ([:u1, umbral.starting_instant, umbral.starting_geometry] if umbral),
+      ([:u2, totality.starting_instant, totality.starting_geometry] if totality),
+      [:greatest, lunar_eclipse.instant, lunar_eclipse.geometry],
+      ([:u3, totality.ending_instant, totality.ending_geometry] if totality),
+      ([:u4, umbral.ending_instant, umbral.ending_geometry] if umbral),
+      [:p4, penumbral.ending_instant, penumbral.ending_geometry]
+    ].compact.map do |key, instant, geometry|
+      Contact.new(key, instant.to_time, geometry.position_angle)
+    end
   end
 
   def lunar_eclipse_phases(lunar_eclipse)

--- a/app/views/lunar_eclipses/_phases.html.erb
+++ b/app/views/lunar_eclipses/_phases.html.erb
@@ -9,32 +9,46 @@
   </p>
 
   <ol class="eclipse-timeline">
-    <% lunar_eclipse_contacts(lunar_eclipse).each do |key, time| %>
+    <% lunar_eclipse_contacts(lunar_eclipse).each do |contact| %>
       <li class="eclipse-contact
-        <%= "eclipse-contact--greatest" if key == :greatest %>">
+        <%= "eclipse-contact--greatest" if contact.key == :greatest %>">
         <div class="flex flex-col sm:flex-row sm:items-baseline
           sm:justify-between sm:gap-4">
           <div class="order-2 sm:order-1">
             <div class="font-semibold">
-              <%= t ".contacts.#{key}.name" %>
+              <%= t ".contacts.#{contact.key}.name" %>
             </div>
             <div class="text-xs text-muted-foreground mt-0.5">
-              <%= t ".contacts.#{key}.description" %>
+              <%= t ".contacts.#{contact.key}.description" %>
             </div>
           </div>
 
           <div class="order-1 flex items-baseline gap-2 mb-0.5 shrink-0
             sm:order-2 sm:block sm:mb-0 sm:text-right">
             <div class="font-mono
-              <%= "font-bold text-accent" if key == :greatest %>">
-              <%= nillable_datetime(time, format: :hm) %>
+              <%= "font-bold text-accent" if contact.key == :greatest %>">
+              <%= nillable_datetime(contact.time, format: :hm) %>
             </div>
             <div class="text-xs text-muted-foreground font-mono">
-              <%= l time, format: :utc_hm %>
+              <%= l contact.time, format: :utc_hm %>
+            </div>
+            <div class="text-xs text-muted-foreground font-mono">
+              <%= t(
+                ".position_angle",
+                angle: format_number(
+                  contact.position_angle.degrees,
+                  unit: :degree,
+                  precision: 1
+                )
+              ) %>
             </div>
           </div>
         </div>
       </li>
     <% end %>
   </ol>
+
+  <p class="text-xs text-muted-foreground mt-4">
+    <%= t ".position_angle_note" %>
+  </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,6 +382,11 @@ en:
         u4:
           description: The Moon leaves the umbra and the partial eclipse ends.
           name: Fourth umbral contact (U4)
+      position_angle: "PA %{angle}"
+      position_angle_note:
+        The position angle is measured on the Moon's limb from celestial north
+        through east, the convention IMCCE and NASA publish, so these values
+        can be compared with a published table directly.
       time_zone: "Times in %{zone}, with UTC underneath."
       title: 🕐 Contacts
     show:

--- a/spec/components/lunar_eclipse_disc_component_spec.rb
+++ b/spec/components/lunar_eclipse_disc_component_spec.rb
@@ -3,13 +3,78 @@
 require "rails_helper"
 
 RSpec.describe LunarEclipseDiscComponent, type: :component do
-  def phase(from: 0, to: 2)
+  def moon_radius_km
+    LunarEclipseDiscComponent::MOON_RADIUS_KM
+  end
+
+  def build_geometry(
+    axis_distance_km:,
+    position_angle:,
+    umbra_km: 4664,
+    penumbra_km: 8254
+  )
+    Astronoby::LunarEclipseGeometry.new(
+      axis_distance: Astronoby::Distance.from_kilometers(axis_distance_km),
+      position_angle: Astronoby::Angle.from_degrees(position_angle),
+      umbra_radius: Astronoby::Distance.from_kilometers(umbra_km),
+      penumbra_radius: Astronoby::Distance.from_kilometers(penumbra_km),
+      moon_distance: Astronoby::Distance.from_kilometers(400_000)
+    )
+  end
+
+  def build_phase(starting_geometry:, ending_geometry:, from: 0, to: 2)
     Astronoby::EclipsePhase.new(
       starting_instant: Astronoby::Instant.from_time(
         Time.utc(2026, 3, 3, 10) + from.hours
       ),
       ending_instant: Astronoby::Instant.from_time(
         Time.utc(2026, 3, 3, 10) + to.hours
+      ),
+      starting_geometry: starting_geometry,
+      ending_geometry: ending_geometry
+    )
+  end
+
+  def build_penumbral_phase(
+    starting_geometry: build_geometry(
+      axis_distance_km: 9989,
+      position_angle: 104.30
+    ),
+    ending_geometry: build_geometry(
+      axis_distance_km: 9994,
+      position_angle: 312.13
+    )
+  )
+    build_phase(
+      starting_geometry: starting_geometry,
+      ending_geometry: ending_geometry
+    )
+  end
+
+  def build_partial_phase
+    build_phase(
+      starting_geometry: build_geometry(
+        axis_distance_km: 6403,
+        position_angle: 96.19
+      ),
+      ending_geometry: build_geometry(
+        axis_distance_km: 6402,
+        position_angle: 320.26
+      )
+    )
+  end
+
+  def build_total_phase(
+    starting_geometry: build_geometry(
+      axis_distance_km: 2926,
+      position_angle: 243.07
+    )
+  )
+    build_phase(
+      starting_geometry: starting_geometry,
+      ending_geometry: build_geometry(
+        axis_distance_km: 2925,
+        position_angle: 173.39
       )
     )
   end
@@ -19,9 +84,10 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
     umbral_magnitude: 1.151,
     penumbral_magnitude: 2.184,
     gamma: -0.376,
-    axis_distance_km: 2401,
-    partial: phase,
-    total: phase(from: 0.5, to: 1.5)
+    geometry: build_geometry(axis_distance_km: 2401, position_angle: 208.22),
+    penumbral: build_penumbral_phase,
+    partial: build_partial_phase,
+    total: build_total_phase
   )
     instance_double(
       Astronoby::LunarEclipse,
@@ -29,10 +95,8 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
       umbral_magnitude: umbral_magnitude,
       penumbral_magnitude: penumbral_magnitude,
       gamma: gamma,
-      shadow_axis_distance: Astronoby::Distance.from_kilometers(
-        axis_distance_km
-      ),
-      penumbral: phase,
+      geometry: geometry,
+      penumbral: penumbral,
       partial: partial,
       total: total,
       penumbral?: kind == :penumbral
@@ -45,7 +109,7 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
       umbral_magnitude: -0.132,
       penumbral_magnitude: 0.956,
       gamma: 1.061,
-      axis_distance_km: 6767,
+      geometry: build_geometry(axis_distance_km: 6767, position_angle: 8.4),
       partial: nil,
       total: nil
     )
@@ -57,7 +121,7 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
       umbral_magnitude: 0.93,
       penumbral_magnitude: 1.965,
       gamma: 0.496,
-      axis_distance_km: 3166,
+      geometry: build_geometry(axis_distance_km: 3166, position_angle: 21.5),
       total: nil
     )
   end
@@ -68,105 +132,168 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
     ).to_html
   end
 
-  def moon_cy(html)
-    html[/<circle cx="0" cy="(-?[\d.]+)" r="1" fill="#d4d0c3"/, 1].to_f
+  def moon_centre(html)
+    match = html.match(
+      /<circle cx="(-?[\d.]+)"\s+cy="(-?[\d.]+)"\s+r="1"\s+fill="#d4d0c3"/m
+    )
+    [match[1].to_f, match[2].to_f]
   end
 
-  def moon_offset(html)
-    moon_cy(html).abs
+  def ghost_centres(html)
+    html
+      .scan(
+        /<circle cx="(-?[\d.]+)" cy="(-?[\d.]+)" r="1" fill="none" stroke="#9c9188"/
+      )
+      .map { |x, y| [x.to_f, y.to_f] }
   end
 
-  def contact_marks(html)
-    html.scan(
-      /<circle cx="-?[\d.]+" cy="-?[\d.]+" r="1" fill="none" stroke="#9c9188"/
-    ).size
+  def shadow_radii(html)
+    html
+      .scan(/<circle\s+cx="0"\s+cy="0"\s+r="([\d.]+)"/m)
+      .flatten
+      .map(&:to_f)
+      .uniq
+      .sort
   end
 
   def view_box(html)
     html[/viewBox="([^"]+)"/, 1].split.map(&:to_f)
   end
 
-  def umbra_radius(html)
-    html
-      .scan(/<circle\s+cx="0"\s+cy="0"\s+r="([\d.]+)"/m)
-      .flatten
-      .map(&:to_f)
-      .min
-  end
-
-  describe "the depth the figure draws the Moon at" do
-    it "puts the whole Moon inside the umbra for a total eclipse" do
-      html = render_disc(build_eclipse, detailed: true)
-
-      expect(umbra_radius(html)).to be >= moon_offset(html) + 1
-    end
-
-    it "straddles the umbra edge for a partial eclipse" do
-      html = render_disc(build_partial_eclipse, detailed: true)
-
-      expect(umbra_radius(html)).to be_between(
-        moon_offset(html) - 1,
-        moon_offset(html) + 1
-      ).exclusive
-    end
-
-    it "keeps the Moon clear of the umbra for a penumbral eclipse" do
-      html = render_disc(build_penumbral_eclipse, detailed: true)
-
-      expect(umbra_radius(html)).to be <= moon_offset(html) - 1
-    end
-
-    it "places the Moon at its distance from the shadow axis" do
-      html = render_disc(build_eclipse(axis_distance_km: 2401), detailed: true)
-
-      expect(moon_offset(html)).to be_within(0.001).of(
-        2401 / LunarEclipseDiscComponent::MOON_RADIUS_KM
+  describe "the shadow it draws" do
+    it "takes both radii from the geometry rather than the magnitudes" do
+      html = render_disc(
+        build_eclipse(
+          geometry: build_geometry(
+            axis_distance_km: 2401,
+            position_angle: 208.22,
+            umbra_km: 2 * moon_radius_km,
+            penumbra_km: 4 * moon_radius_km
+          ),
+          umbral_magnitude: 99,
+          penumbral_magnitude: 99
+        ),
+        detailed: true
       )
+
+      expect(shadow_radii(html)).to eq([2.0, 4.0])
     end
   end
 
-  describe "which side of the axis the Moon passes" do
-    it "draws a Moon north of the axis above it" do
-      html = render_disc(build_eclipse(gamma: 0.348), detailed: true)
+  describe "where it puts the Moon" do
+    it "places it at its distance from the shadow axis" do
+      html = render_disc(build_eclipse, detailed: true)
+      x, y = moon_centre(html)
 
-      expect(moon_cy(html)).to be_negative
+      expect(Math.hypot(x, y)).to be_within(0.001).of(2401 / moon_radius_km)
     end
 
-    it "draws a Moon south of the axis below it" do
-      html = render_disc(build_eclipse(gamma: -0.348), detailed: true)
+    it "reads greatest eclipse as the axis to Moon direction" do
+      html = render_disc(
+        build_eclipse(
+          geometry: build_geometry(axis_distance_km: 2 * moon_radius_km, position_angle: 0)
+        ),
+        detailed: true
+      )
 
-      expect(moon_cy(html)).to be_positive
+      expect(moon_centre(html)).to eq([0.0, -2.0])
+    end
+
+    it "puts a Moon east of the axis to the right" do
+      html = render_disc(
+        build_eclipse(
+          geometry: build_geometry(axis_distance_km: 2 * moon_radius_km, position_angle: 90)
+        ),
+        detailed: true
+      )
+
+      expect(moon_centre(html)).to eq([2.0, 0.0])
     end
   end
 
-  describe "the detailed figure" do
-    it "marks every contact on the Moon's path" do
+  describe "the contact marks" do
+    it "turns an external tangency away from the shadow axis" do
+      html = render_disc(
+        build_eclipse(
+          penumbral: build_penumbral_phase(
+            starting_geometry: build_geometry(
+              axis_distance_km: 2 * moon_radius_km,
+              position_angle: 0
+            )
+          )
+        ),
+        detailed: true
+      )
+
+      expect(ghost_centres(html).first).to eq([0.0, 2.0])
+    end
+
+    it "keeps an internal tangency facing the shadow axis" do
+      html = render_disc(
+        build_eclipse(
+          total: build_total_phase(
+            starting_geometry: build_geometry(
+              axis_distance_km: 2 * moon_radius_km,
+              position_angle: 0
+            )
+          )
+        ),
+        detailed: true
+      )
+
+      expect(ghost_centres(html)).to include([0.0, -2.0])
+    end
+
+    it "marks every contact of a total eclipse" do
       html = render_disc(build_eclipse, detailed: true)
 
-      expect(html.scan("<line ").size).to eq(1)
-      expect(contact_marks(html)).to eq(6)
+      expect(ghost_centres(html).size).to eq(6)
     end
 
     it "marks only the penumbral contacts when there is no umbral phase" do
       html = render_disc(build_penumbral_eclipse, detailed: true)
 
-      expect(contact_marks(html)).to eq(2)
+      expect(ghost_centres(html).size).to eq(2)
     end
 
     it "marks the umbral but not the totality contacts for a partial" do
       html = render_disc(build_partial_eclipse, detailed: true)
 
-      expect(contact_marks(html)).to eq(4)
+      expect(ghost_centres(html).size).to eq(4)
+    end
+
+    it "lies on the path drawn between the penumbral contacts" do
+      html = render_disc(build_eclipse, detailed: true)
+      ends = ghost_centres(html).first(2)
+      line = html.match(
+        /<line\s+x1="(-?[\d.]+)"\s+y1="(-?[\d.]+)"\s+x2="(-?[\d.]+)"\s+y2="(-?[\d.]+)"/m
+      )
+
+      expect([[line[1].to_f, line[2].to_f], [line[3].to_f, line[4].to_f]])
+        .to eq(ends)
+    end
+
+    it "keeps every contact on that path" do
+      html = render_disc(build_eclipse, detailed: true)
+      first, last = ghost_centres(html).first(2)
+      run = [last.first - first.first, last.last - first.last]
+
+      ghost_centres(html).drop(2).each do |x, y|
+        cross = run.first * (y - first.last) - run.last * (x - first.first)
+        expect(cross.abs / Math.hypot(*run)).to be < 0.05
+      end
     end
   end
 
   describe "the compact figure" do
     it "frames the Moon in a square viewBox" do
       html = render_disc(build_eclipse)
-      _x, y, width, height = view_box(html)
+      x, y, width, height = view_box(html)
+      moon_x, moon_y = moon_centre(html)
 
       expect(width).to eq(height)
-      expect(y + height / 2).to be_within(0.001).of(moon_cy(html))
+      expect(x + width / 2).to be_within(0.001).of(moon_x)
+      expect(y + height / 2).to be_within(0.001).of(moon_y)
     end
 
     it "renders as tall as it is wide" do


### PR DESCRIPTION
Before, the illustration used to infer the umbra and penumbra radii from the magnitudes and place the contacts on a horizontal path.

Now, both come straight from the geometry, so the contacts sit where they actually happen and the `Contacts` card can show their published position angles.