### PR TITLE
Show lunar eclipse visibility from the observer's location

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rhannequin/astronoby.git
-  revision: 85e9b3866d58beb1a9ac02865ba0d908ccfb44db
+  revision: 53d701516bc2bb65d518304d401691d793189cb7
   branch: main
   specs:
     astronoby (0.10.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -476,6 +476,63 @@ h1, h2, h3 {
   color: hsl(var(--muted-foreground));
 }
 
+.eclipse-visibility-badge--entirely_visible {
+  border-color: hsl(150 45% 40% / 0.5);
+  background: hsl(150 45% 40% / 0.12);
+  color: hsl(150 55% 28%);
+}
+
+.dark .eclipse-visibility-badge--entirely_visible {
+  color: hsl(150 60% 70%);
+}
+
+.eclipse-visibility-badge--begins_before_moonrise,
+.eclipse-visibility-badge--ends_after_moonset,
+.eclipse-visibility-badge--partially_visible {
+  border-color: hsl(var(--accent) / 0.5);
+  background: hsl(var(--accent) / 0.12);
+  color: hsl(35 70% 32%);
+}
+
+.dark .eclipse-visibility-badge--begins_before_moonrise,
+.dark .eclipse-visibility-badge--ends_after_moonset,
+.dark .eclipse-visibility-badge--partially_visible {
+  color: hsl(35 85% 72%);
+}
+
+.eclipse-visibility-badge--not_visible {
+  color: hsl(220 18% 38%);
+  background: hsl(var(--muted-foreground) / 0.1);
+}
+
+.dark .eclipse-visibility-badge--not_visible {
+  color: hsl(var(--muted-foreground));
+}
+
+.eclipse-visibility-summary {
+  border-radius: 0.5rem;
+  border: 1px solid hsl(var(--border) / 0.6);
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.eclipse-visibility-summary--entirely_visible {
+  border-color: hsl(150 45% 40% / 0.4);
+  background: hsl(150 45% 40% / 0.08);
+}
+
+.eclipse-visibility-summary--begins_before_moonrise,
+.eclipse-visibility-summary--ends_after_moonset,
+.eclipse-visibility-summary--partially_visible {
+  border-color: hsl(var(--accent) / 0.4);
+  background: hsl(var(--accent) / 0.08);
+}
+
+.eclipse-visibility-summary--not_visible {
+  background: hsl(var(--muted-foreground) / 0.08);
+}
+
 .eclipse-year-nav {
   display: inline-flex;
   align-items: center;

--- a/app/helpers/lunar_eclipse_helper.rb
+++ b/app/helpers/lunar_eclipse_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module LunarEclipseHelper
-  Contact = Struct.new(:key, :time, :position_angle)
+  HorizonEvent = Struct.new(:name, :time)
 
-  def lunar_eclipse_contacts(lunar_eclipse)
+  def lunar_eclipse_contacts(lunar_eclipse, observer)
     penumbral = lunar_eclipse.penumbral
     umbral = lunar_eclipse.partial
     totality = lunar_eclipse.total
@@ -17,7 +17,12 @@ module LunarEclipseHelper
       ([:u4, umbral.ending_instant, umbral.ending_geometry] if umbral),
       [:p4, penumbral.ending_instant, penumbral.ending_geometry]
     ].compact.map do |key, instant, geometry|
-      Contact.new(key, instant.to_time, geometry.position_angle)
+      LunarEclipseContact.new(
+        key: key,
+        instant: instant,
+        geometry: geometry,
+        observer: observer
+      )
     end
   end
 
@@ -31,5 +36,21 @@ module LunarEclipseHelper
 
   def lunar_eclipse_date(lunar_eclipse)
     lunar_eclipse.instant.to_time.utc.to_date
+  end
+
+  def lunar_eclipse_visibility(lunar_eclipse, observer)
+    lunar_eclipse.visibility_from(observer)
+  end
+
+  def lunar_eclipse_horizon_events(lunar_eclipse, visibility)
+    first_contact = lunar_eclipse.penumbral.starting_instant
+    last_contact = lunar_eclipse.penumbral.ending_instant
+
+    visibility.observable_windows.flat_map do |window|
+      [
+        ([:moonrise, window.first] unless window.first == first_contact),
+        ([:moonset, window.last] unless window.last == last_contact)
+      ].compact
+    end.map { |name, instant| HorizonEvent.new(name, instant.to_time) }
   end
 end

--- a/app/models/lunar_eclipse_contact.rb
+++ b/app/models/lunar_eclipse_contact.rb
@@ -18,10 +18,17 @@ class LunarEclipseContact
   delegate :altitude, :azimuth, to: :horizontal
 
   def above_horizon?
-    altitude.positive?
+    altitude > horizon_angle
   end
 
   private
+
+  def horizon_angle
+    Astronoby::Horizon.angle_for(
+      body: Astronoby::Moon,
+      distance: @geometry.moon_distance
+    )
+  end
 
   def horizontal
     @horizontal ||= Astronoby::Moon

--- a/app/models/lunar_eclipse_contact.rb
+++ b/app/models/lunar_eclipse_contact.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class LunarEclipseContact
+  attr_reader :key, :instant, :geometry
+
+  def initialize(key:, instant:, geometry:, observer:)
+    @key = key
+    @instant = instant
+    @geometry = geometry
+    @observer = observer
+  end
+
+  def time
+    @time ||= @instant.to_time
+  end
+
+  delegate :position_angle, to: :@geometry
+  delegate :altitude, :azimuth, to: :horizontal
+
+  def above_horizon?
+    altitude.positive?
+  end
+
+  private
+
+  def horizontal
+    @horizontal ||= Astronoby::Moon
+      .new(ephem: SPK.for_time(time), instant: @instant)
+      .observed_by(@observer)
+      .horizontal
+  end
+end

--- a/app/views/lunar_eclipses/_eclipse_card.html.erb
+++ b/app/views/lunar_eclipses/_eclipse_card.html.erb
@@ -14,6 +14,11 @@
       <%= t "lunar_eclipses.kinds.#{lunar_eclipse.kind}.name" %>
     </span>
 
+    <span class="eclipse-badge
+      eclipse-visibility-badge--<%= visibility.circumstance %>">
+      <%= t "lunar_eclipses.visibility.badges.#{visibility.circumstance}" %>
+    </span>
+
     <div class="text-lg font-bold mt-2 leading-tight">
       <%= l lunar_eclipse_date(lunar_eclipse), format: :long %>
     </div>

--- a/app/views/lunar_eclipses/_phases.html.erb
+++ b/app/views/lunar_eclipses/_phases.html.erb
@@ -9,7 +9,7 @@
   </p>
 
   <ol class="eclipse-timeline">
-    <% lunar_eclipse_contacts(lunar_eclipse).each do |contact| %>
+    <% lunar_eclipse_contacts(lunar_eclipse, observer).each do |contact| %>
       <li class="eclipse-contact
         <%= "eclipse-contact--greatest" if contact.key == :greatest %>">
         <div class="flex flex-col sm:flex-row sm:items-baseline
@@ -39,6 +39,22 @@
                   contact.position_angle.degrees,
                   unit: :degree,
                   precision: 1
+                )
+              ) %>
+            </div>
+            <div class="text-xs font-mono
+              <%= contact.above_horizon? ? "text-muted-foreground" : "opacity-60" %>">
+              <%= t(
+                ".horizontal",
+                altitude: format_number(
+                  contact.altitude.degrees,
+                  unit: :degree,
+                  precision: 1
+                ),
+                azimuth: format_number(
+                  contact.azimuth.degrees,
+                  unit: :degree,
+                  precision: 0
                 )
               ) %>
             </div>

--- a/app/views/lunar_eclipses/_visibility.html.erb
+++ b/app/views/lunar_eclipses/_visibility.html.erb
@@ -1,0 +1,72 @@
+<div class="rounded-lg border bg-card text-card-foreground shadow-sm
+  cosmic-card">
+  <h3 class="text-xl font-bold mb-1 text-primary">
+    <%= t ".title" %>
+  </h3>
+
+  <p class="text-sm text-muted-foreground mb-4">
+    <%= t ".subtitle" %>
+  </p>
+
+  <div class="eclipse-visibility-summary
+    eclipse-visibility-summary--<%= visibility.circumstance %>">
+    <%= t "lunar_eclipses.visibility.circumstances.#{visibility.circumstance}" %>
+  </div>
+
+  <dl class="mt-4 space-y-2 text-sm">
+    <% lunar_eclipse_phases(lunar_eclipse).each do |name, _phase| %>
+      <div class="flex items-baseline justify-between gap-4">
+        <dt class="text-muted-foreground">
+          <%= t "lunar_eclipses.phase_names.#{name}" %>
+        </dt>
+        <dd class="font-semibold text-right">
+          <%= t(
+            "lunar_eclipses.visibility.coverages.#{visibility.coverage(name)}"
+          ) %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
+
+  <% horizon_events = lunar_eclipse_horizon_events(lunar_eclipse, visibility) %>
+  <% if horizon_events.any? %>
+    <dl class="mt-4 pt-4 border-t space-y-2 text-sm">
+      <% horizon_events.each do |horizon_event| %>
+        <div class="flex items-baseline justify-between gap-4">
+          <dt class="text-muted-foreground">
+            <%= t "lunar_eclipses.visibility.horizon_events.#{horizon_event.name}" %>
+          </dt>
+          <dd class="font-mono text-right">
+            <%= nillable_datetime(horizon_event.time, format: :hm) %>
+            <span class="text-xs text-muted-foreground">
+              <%= l horizon_event.time, format: :utc_hm %>
+            </span>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+
+  <% if visibility.visible? %>
+    <dl class="mt-4 pt-4 border-t space-y-2 text-sm">
+      <% visibility.observable_windows.each do |window| %>
+        <div class="flex items-baseline justify-between gap-4">
+          <dt class="text-muted-foreground">
+            <%= t ".window" %>
+          </dt>
+          <dd class="font-mono text-right">
+            <%= t(
+              ".window_range",
+              from: l(window.first.to_time.in_time_zone, format: :hm),
+              to: l(window.last.to_time.in_time_zone, format: :hm)
+            ) %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
+
+  <p class="text-xs text-muted-foreground mt-4">
+    <%= t ".note" %>
+  </p>
+</div>

--- a/app/views/lunar_eclipses/index.html.erb
+++ b/app/views/lunar_eclipses/index.html.erb
@@ -22,11 +22,16 @@
 
 <% if @lunar_eclipses.any? %>
   <%= cache(
-    lunar_eclipse_cache_key("list/#{@selected_year}/#{time_zone_cache_key}")
+    lunar_eclipse_cache_key("list/#{@selected_year}/#{observer_cache_key}"),
+    expires_in: 1.week
   ) do %>
     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
       <% @lunar_eclipses.each do |lunar_eclipse| %>
-        <%= render "eclipse_card", lunar_eclipse: lunar_eclipse %>
+        <%= render(
+          "eclipse_card",
+          lunar_eclipse: lunar_eclipse,
+          visibility: lunar_eclipse_visibility(lunar_eclipse, @observer)
+        ) %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/lunar_eclipses/show.html.erb
+++ b/app/views/lunar_eclipses/show.html.erb
@@ -9,16 +9,26 @@
 <% end %>
 
 <%= cache(
-  lunar_eclipse_cache_key("details/#{@date.iso8601}/#{time_zone_cache_key}")
+  lunar_eclipse_cache_key("details/#{@date.iso8601}/#{observer_cache_key}"),
+  expires_in: 1.week
 ) do %>
   <%= render "hero", lunar_eclipse: @lunar_eclipse, date: @date %>
 
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
     <div class="lg:col-span-2 space-y-6">
-      <%= render "phases", lunar_eclipse: @lunar_eclipse %>
+      <%= render(
+        "phases",
+        lunar_eclipse: @lunar_eclipse,
+        observer: @observer
+      ) %>
     </div>
 
     <div class="space-y-6">
+      <%= render(
+        "visibility",
+        lunar_eclipse: @lunar_eclipse,
+        visibility: lunar_eclipse_visibility(@lunar_eclipse, @observer)
+      ) %>
       <%= render "durations", lunar_eclipse: @lunar_eclipse %>
       <%= render "about", lunar_eclipse: @lunar_eclipse %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,7 +416,7 @@ en:
         moonset: Moon sets
       note: A lunar eclipse happens at the same moment everywhere. All that
         changes from place to place is whether the Moon is above the horizon.
-      subtitle: From your location, using your saved coordinates.
+      subtitle: From your location.
       title: 👁 Visibility
       window: Moon above the horizon
       window_range: "%{from} – %{to}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -382,6 +382,7 @@ en:
         u4:
           description: The Moon leaves the umbra and the partial eclipse ends.
           name: Fourth umbral contact (U4)
+      horizontal: "%{altitude} alt · %{azimuth} az"
       position_angle: "PA %{angle}"
       position_angle_note:
         The position angle is measured on the Moon's limb from celestial north
@@ -392,6 +393,33 @@ en:
     show:
       back: "All eclipses in %{year}"
       title: Lunar Eclipse on %{date}
+    visibility:
+      badges:
+        begins_before_moonrise: Partly visible
+        ends_after_moonset: Partly visible
+        entirely_visible: Visible
+        not_visible: Not visible
+        partially_visible: Partly visible
+      circumstances:
+        begins_before_moonrise: The eclipse is already under way when the Moon
+          rises.
+        ends_after_moonset: The Moon sets while the eclipse is still under way.
+        entirely_visible: The Moon is up from the first to the last contact.
+        not_visible: The Moon is below the horizon for the whole eclipse.
+        partially_visible: The Moon crosses the horizon during the eclipse.
+      coverages:
+        entirely_visible: Entirely visible
+        not_visible: Not visible
+        partially_visible: Partly visible
+      horizon_events:
+        moonrise: Moon rises
+        moonset: Moon sets
+      note: A lunar eclipse happens at the same moment everywhere. All that
+        changes from place to place is whether the Moon is above the horizon.
+      subtitle: From your location, using your saved coordinates.
+      title: 👁 Visibility
+      window: Moon above the horizon
+      window_range: "%{from} – %{to}"
     year_selector:
       next: "Eclipses in %{year}"
       previous: "Eclipses in %{year}"

--- a/spec/components/lunar_eclipse_disc_component_spec.rb
+++ b/spec/components/lunar_eclipse_disc_component_spec.rb
@@ -11,19 +11,25 @@ RSpec.describe LunarEclipseDiscComponent, type: :component do
     axis_distance_km:,
     position_angle:,
     umbra_km: 4664,
-    penumbra_km: 8254
+    penumbra_km: 8254,
+    north_of_axis: true
   )
     Astronoby::LunarEclipseGeometry.new(
       axis_distance: Astronoby::Distance.from_kilometers(axis_distance_km),
       position_angle: Astronoby::Angle.from_degrees(position_angle),
       umbra_radius: Astronoby::Distance.from_kilometers(umbra_km),
       penumbra_radius: Astronoby::Distance.from_kilometers(penumbra_km),
-      moon_distance: Astronoby::Distance.from_kilometers(400_000)
+      moon_distance: Astronoby::Distance.from_kilometers(400_000),
+      moon_coordinates: Astronoby::Coordinates::Equatorial.new(
+        right_ascension: Astronoby::Angle.from_hours(11.64),
+        declination: Astronoby::Angle.from_degrees(2.68)
+      ),
+      north_of_axis: north_of_axis
     )
   end
 
   def build_phase(starting_geometry:, ending_geometry:, from: 0, to: 2)
-    Astronoby::EclipsePhase.new(
+    Astronoby::LunarEclipsePhase.new(
       starting_instant: Astronoby::Instant.from_time(
         Time.utc(2026, 3, 3, 10) + from.hours
       ),

--- a/spec/models/lunar_eclipse_contact_spec.rb
+++ b/spec/models/lunar_eclipse_contact_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LunarEclipseContact do
+  describe "#altitude" do
+    it "corrects the geocentric place for the observer's parallax" do
+      observer = paris
+      eclipse = total_eclipse_of_2025_03_14
+      instant = eclipse.total.starting_instant
+
+      contact = described_class.new(
+        key: :u2,
+        instant: instant,
+        geometry: eclipse.total.starting_geometry,
+        observer: observer
+      )
+
+      geocentric = eclipse
+        .total
+        .starting_geometry
+        .moon_coordinates
+        .to_horizontal(time: instant.to_time, observer: observer)
+
+      expect(contact.altitude.degrees)
+        .to be_within(0.05).of(geocentric.altitude.degrees - 0.9)
+    end
+  end
+
+  describe "#above_horizon?" do
+    it "is true before the Moon sets and false after" do
+      eclipse = total_eclipse_of_2025_03_14
+
+      before_moonset = described_class.new(
+        key: :u1,
+        instant: eclipse.partial.starting_instant,
+        geometry: eclipse.partial.starting_geometry,
+        observer: paris
+      )
+      after_moonset = described_class.new(
+        key: :u2,
+        instant: eclipse.total.starting_instant,
+        geometry: eclipse.total.starting_geometry,
+        observer: paris
+      )
+
+      expect(before_moonset).to be_above_horizon
+      expect(after_moonset).not_to be_above_horizon
+    end
+
+    it "agrees with what the eclipse reports for that instant" do
+      eclipse = total_eclipse_of_2025_03_14
+      visibility = eclipse.visibility_from(paris)
+
+      contacts = [
+        [
+          eclipse.penumbral.starting_instant,
+          eclipse.penumbral.starting_geometry
+        ],
+        [eclipse.partial.starting_instant, eclipse.partial.starting_geometry],
+        [eclipse.total.starting_instant, eclipse.total.starting_geometry],
+        [eclipse.instant, eclipse.geometry],
+        [eclipse.penumbral.ending_instant, eclipse.penumbral.ending_geometry]
+      ]
+
+      contacts.each do |instant, geometry|
+        contact = described_class.new(
+          key: :contact,
+          instant: instant,
+          geometry: geometry,
+          observer: paris
+        )
+
+        expect(contact.above_horizon?)
+          .to eq(visibility.above_horizon_at?(instant))
+      end
+    end
+  end
+
+  def paris
+    Observer.new(
+      astronoby_observer: Astronoby::Observer.new(
+        latitude: Astronoby::Angle.from_degrees(48.85341),
+        longitude: Astronoby::Angle.from_degrees(2.3488),
+        utc_offset: "+01:00"
+      ),
+      time_zone: Time.find_zone("Europe/Paris")
+    )
+  end
+
+  def total_eclipse_of_2025_03_14
+    start_time = Time.utc(2025)
+
+    Astronoby::Moon.eclipse_events(
+      ephem: SPK.for_time(start_time),
+      start_time: start_time,
+      end_time: start_time.end_of_year
+    ).first
+  end
+end

--- a/spec/models/moon_interference_spec.rb
+++ b/spec/models/moon_interference_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe MoonInterference do
           date: Date.new(2025, 9, 3)
         )
 
-        # Night from 18:41 to 05:18 (637 minutes)
+        # Night from 18:41 to 05:18 (636 minutes)
         # Moon above the horizon from 17:15 to 00:28 (next day)
-        # Moon above the horizon during night from 18:41 to 00:28 (347 minutes)
-        # Percentage: 347 * 100 / 637 = 55%
-        expect(moon_interference.percentage).to eq(55)
+        # Moon above the horizon during night from 18:41 to 00:28 (346 minutes)
+        # Percentage: 346 * 100 / 636 = 54%
+        expect(moon_interference.percentage).to eq(54)
       end
     end
 

--- a/spec/requests/lunar_eclipses_spec.rb
+++ b/spec/requests/lunar_eclipses_spec.rb
@@ -4,6 +4,15 @@ require "rails_helper"
 
 RSpec.describe LunarEclipsesController, type: :request do
   describe "GET /lunar_eclipses" do
+    it "says whether each eclipse is visible from the observer" do
+      travel_to Time.utc(2027, 1, 1) do
+        get lunar_eclipses_path(year: 2027)
+
+        expect(response.body).to include("Visible")
+        expect(response.body).to include("Not visible")
+      end
+    end
+
     it "returns a successful response" do
       travel_to Time.utc(2026, 8, 25) do
         get lunar_eclipses_path
@@ -81,6 +90,36 @@ RSpec.describe LunarEclipsesController, type: :request do
   end
 
   describe "GET /lunar_eclipses/:id" do
+    it "describes what the observer sees of the eclipse" do
+      travel_to Time.utc(2025, 1, 1) do
+        get lunar_eclipse_path(id: "2025-03-14")
+
+        expect(response.body).to include("Visibility")
+        expect(response.body)
+          .to include("The Moon sets while the eclipse is still under way.")
+        expect(response.body).to include("Moon sets")
+      end
+    end
+
+    it "shows where to look for the Moon at each contact" do
+      travel_to Time.utc(2025, 1, 1) do
+        get lunar_eclipse_path(id: "2025-03-14")
+
+        expect(response.body).to include("20.8° alt · 249° az")
+        expect(response.body).to include("-3.1° alt · 277° az")
+      end
+    end
+
+    it "reports each phase separately" do
+      travel_to Time.utc(2025, 1, 1) do
+        get lunar_eclipse_path(id: "2025-03-14")
+
+        # Paris loses the Moon before totality begins.
+        expect(response.body).to include("Totality")
+        expect(response.body).to include("Not visible")
+      end
+    end
+
     context "with a valid date" do
       it "returns a successful response" do
         travel_to Time.utc(2026, 8, 25) do


### PR DESCRIPTION
A lunar eclipse happens at the same moment everywhere, so the pages only showed geocentric circumstances. Whether you can see any of it depends one thing: whether the Moon is above your horizon.

A visibility card says whether the eclipse is seen whole, in part or not at all, how much of each phase happens with the Moon up, when it rises or sets during the eclipse. The year list displays the same as a badge, so a year can be scanned without opening every eclipse. The contacts card has the Moon's topocentric altitude and azimuth at each contact, which says where to look and makes the contacts below the horizon plain from their negative altitude.