### PR TITLE
Almanac page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 group :test do
   gem "capybara"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    shoulda-matchers (8.0.1)
+      activesupport (>= 7.2)
     solid_cable (4.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -463,6 +465,7 @@ DEPENDENCIES
   rubocop-capybara
   rubocop-rails
   selenium-webdriver
+  shoulda-matchers
   solid_cable
   solid_cache
   solid_queue

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -712,13 +712,13 @@ h1, h2, h3 {
   color: hsl(240 90% 82%);
 }
 
-.almanac-badge--maximum-elongation {
+.almanac-badge--greatest-elongation {
   border-color: hsl(var(--accent) / 0.5);
   background: hsl(var(--accent) / 0.12);
   color: hsl(280 55% 42%);
 }
 
-.dark .almanac-badge--maximum-elongation {
+.dark .almanac-badge--greatest-elongation {
   color: hsl(280 90% 80%);
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -750,6 +750,16 @@ h1, h2, h3 {
   color: hsl(240 90% 82%);
 }
 
+.almanac-badge--greatest-elongation {
+  border-color: hsl(var(--accent) / 0.5);
+  background: hsl(var(--accent) / 0.12);
+  color: hsl(280 55% 42%);
+}
+
+.dark .almanac-badge--greatest-elongation {
+  color: hsl(280 90% 80%);
+}
+
 .almanac-badge--lunar-eclipse {
   border-color: rgba(156, 69, 38, 0.6);
   background: rgba(156, 69, 38, 0.15);
@@ -760,24 +770,20 @@ h1, h2, h3 {
   color: #e08a63;
 }
 
-.almanac-badge--greatest-elongation {
-  border-color: hsl(var(--accent) / 0.5);
-  background: hsl(var(--accent) / 0.12);
-  color: hsl(280 55% 42%);
+.almanac-badge--march-equinox,
+.almanac-badge--june-solstice,
+.almanac-badge--september-equinox,
+.almanac-badge--december-solstice {
+  border-color: rgba(217, 143, 12, 0.5);
+  background: rgba(253, 184, 19, 0.18);
+  color: #8a5a08;
 }
 
-.dark .almanac-badge--lunar-eclipse {
-  border-color: rgba(156, 69, 38, 0.6);
-  background: rgba(156, 69, 38, 0.15);
-  color: #8a3a22;
-}
-
-.dark .almanac-badge--lunar-eclipse {
-  color: #e08a63;
-}
-
-.almanac-badge--greatest-elongation {
-  color: hsl(280 90% 80%);
+.dark .almanac-badge--march-equinox,
+.dark .almanac-badge--june-solstice,
+.dark .almanac-badge--september-equinox,
+.dark .almanac-badge--december-solstice {
+  color: #f0b429;
 }
 
 @media (max-width: 768px) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -615,6 +615,45 @@ h1, h2, h3 {
   padding-bottom: 0.35rem;
 }
 
+.almanac-rhythm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 1.25rem;
+}
+
+.almanac-apsis-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.85rem;
+  margin: 0;
+  padding: 0 0 0 1.25rem;
+  list-style: none;
+  border-left: 1px solid hsl(var(--border) / 0.6);
+}
+
+.almanac-apsis {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.almanac-apsis-label {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-apsis-day {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--muted-foreground));
+}
+
 .almanac-phase-strip {
   display: flex;
   flex-wrap: wrap;
@@ -770,6 +809,25 @@ h1, h2, h3 {
   color: #e08a63;
 }
 
+.almanac-badge--earth-aphelion,
+.almanac-badge--earth-perihelion {
+  border-color: hsl(168 60% 38% / 0.5);
+  background: hsl(168 60% 38% / 0.12);
+  color: hsl(168 70% 27%);
+}
+
+.dark .almanac-badge--earth-aphelion,
+.dark .almanac-badge--earth-perihelion {
+  color: hsl(168 60% 62%);
+}
+
+.almanac-badge--moon-apogee,
+.almanac-badge--moon-perigee {
+  border-color: hsl(var(--muted-foreground) / 0.35);
+  background: hsl(var(--muted-foreground) / 0.08);
+  color: hsl(var(--muted-foreground));
+}
+
 .almanac-badge--moon-planet-conjunction,
 .almanac-badge--planetary-conjunction {
   border-color: hsl(200 70% 45% / 0.5);
@@ -777,7 +835,25 @@ h1, h2, h3 {
   color: hsl(200 75% 32%);
 }
 
-.dark .almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--earth-aphelion,
+.almanac-badge--earth-perihelion {
+  border-color: hsl(168 60% 38% / 0.5);
+  background: hsl(168 60% 38% / 0.12);
+  color: hsl(168 70% 27%);
+}
+
+.dark .almanac-badge--earth-aphelion,
+.dark .almanac-badge--earth-perihelion {
+  color: hsl(168 60% 62%);
+}
+.almanac-badge--moon-apogee,
+.almanac-badge--moon-perigee {
+  border-color: hsl(var(--muted-foreground) / 0.35);
+  background: hsl(var(--muted-foreground) / 0.08);
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-badge--moon-planet-conjunction,
 .dark .almanac-badge--planetary-conjunction {
   color: hsl(200 85% 72%);
 }
@@ -791,14 +867,52 @@ h1, h2, h3 {
   color: #8a5a08;
 }
 
-.dark .almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--earth-aphelion,
+.almanac-badge--earth-perihelion {
+  border-color: hsl(168 60% 38% / 0.5);
+  background: hsl(168 60% 38% / 0.12);
+  color: hsl(168 70% 27%);
+}
+
+.dark .almanac-badge--earth-aphelion,
+.dark .almanac-badge--earth-perihelion {
+  color: hsl(168 60% 62%);
+}
+
+.almanac-badge--moon-apogee,
+.almanac-badge--moon-perigee {
+  border-color: hsl(var(--muted-foreground) / 0.35);
+  background: hsl(var(--muted-foreground) / 0.08);
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-badge--moon-planet-conjunction,
 .almanac-badge--planetary-conjunction {
   border-color: hsl(200 70% 45% / 0.5);
   background: hsl(200 70% 45% / 0.12);
   color: hsl(200 75% 32%);
 }
 
-.dark .almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--earth-aphelion,
+.almanac-badge--earth-perihelion {
+  border-color: hsl(168 60% 38% / 0.5);
+  background: hsl(168 60% 38% / 0.12);
+  color: hsl(168 70% 27%);
+}
+
+.dark .almanac-badge--earth-aphelion,
+.dark .almanac-badge--earth-perihelion {
+  color: hsl(168 60% 62%);
+}
+
+.almanac-badge--moon-apogee,
+.almanac-badge--moon-perigee {
+  border-color: hsl(var(--muted-foreground) / 0.35);
+  background: hsl(var(--muted-foreground) / 0.08);
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-badge--moon-planet-conjunction,
 .dark .almanac-badge--planetary-conjunction {
   color: hsl(200 85% 72%);
 }
@@ -811,6 +925,11 @@ h1, h2, h3 {
 }
 
 @media (max-width: 768px) {
+  .almanac-apsis-strip {
+    padding-left: 0;
+    border-left: none;
+  }
+
   .almanac-board {
     padding-left: 1.6rem;
   }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -582,3 +582,152 @@ h1, h2, h3 {
     opacity: 0.7;
   }
 }
+
+.almanac-board {
+  position: relative;
+  padding-left: 2.25rem;
+}
+
+.almanac-board::before {
+  content: '';
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.35rem;
+  width: 1px;
+  background: linear-gradient(
+      to bottom,
+      hsl(var(--accent) / 0.6),
+      hsl(var(--border) / 0.5)
+  );
+}
+
+.almanac-month + .almanac-month {
+  margin-top: 1.75rem;
+}
+
+.almanac-month-label {
+  margin-bottom: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-timeline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.almanac-event {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  padding: 0.9rem 0;
+  border-bottom: 1px solid hsl(var(--border) / 0.2);
+}
+
+.almanac-event:last-child {
+  border-bottom: none;
+}
+
+.almanac-event::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -2.24rem;
+  width: 0.7rem;
+  height: 0.7rem;
+  margin-top: -0.35rem;
+  border-radius: 50%;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--muted-foreground) / 0.6);
+}
+
+.almanac-event-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 3.25rem;
+  padding: 0.4rem 0;
+  border-radius: 0.5rem;
+  background: hsl(var(--background) / 0.5);
+  border: 1px solid hsl(var(--border) / 0.3);
+}
+
+.dark .almanac-event-date {
+  background: hsl(var(--card) / 0.25);
+}
+
+.almanac-event-day {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.almanac-event-weekday {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-event-body {
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.almanac-event-time {
+  margin-left: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--muted-foreground));
+}
+
+.almanac-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid hsl(var(--border) / 0.6);
+  padding: 0.125rem 0.625rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.almanac-badge--opposition {
+  border-color: hsl(var(--primary) / 0.5);
+  background: hsl(var(--primary) / 0.12);
+  color: hsl(240 70% 42%);
+}
+
+.dark .almanac-badge--opposition {
+  color: hsl(240 90% 82%);
+}
+
+.almanac-badge--maximum-elongation {
+  border-color: hsl(var(--accent) / 0.5);
+  background: hsl(var(--accent) / 0.12);
+  color: hsl(280 55% 42%);
+}
+
+.dark .almanac-badge--maximum-elongation {
+  color: hsl(280 90% 80%);
+}
+
+@media (max-width: 768px) {
+  .almanac-board {
+    padding-left: 1.6rem;
+  }
+
+  .almanac-event::before {
+    left: -1.59rem;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -809,6 +809,22 @@ h1, h2, h3 {
   color: #e08a63;
 }
 
+.almanac-badge--march-equinox,
+.almanac-badge--june-solstice,
+.almanac-badge--september-equinox,
+.almanac-badge--december-solstice {
+  border-color: rgba(217, 143, 12, 0.5);
+  background: rgba(253, 184, 19, 0.18);
+  color: #8a5a08;
+}
+
+.dark .almanac-badge--march-equinox,
+.dark .almanac-badge--june-solstice,
+.dark .almanac-badge--september-equinox,
+.dark .almanac-badge--december-solstice {
+  color: #f0b429;
+}
+
 .almanac-badge--earth-aphelion,
 .almanac-badge--earth-perihelion {
   border-color: hsl(168 60% 38% / 0.5);
@@ -821,13 +837,6 @@ h1, h2, h3 {
   color: hsl(168 60% 62%);
 }
 
-.almanac-badge--moon-apogee,
-.almanac-badge--moon-perigee {
-  border-color: hsl(var(--muted-foreground) / 0.35);
-  background: hsl(var(--muted-foreground) / 0.08);
-  color: hsl(var(--muted-foreground));
-}
-
 .almanac-badge--moon-planet-conjunction,
 .almanac-badge--planetary-conjunction {
   border-color: hsl(200 70% 45% / 0.5);
@@ -835,99 +844,22 @@ h1, h2, h3 {
   color: hsl(200 75% 32%);
 }
 
-.dark .almanac-badge--earth-aphelion,
-.almanac-badge--earth-perihelion {
-  border-color: hsl(168 60% 38% / 0.5);
-  background: hsl(168 60% 38% / 0.12);
-  color: hsl(168 70% 27%);
-}
-
-.dark .almanac-badge--earth-aphelion,
-.dark .almanac-badge--earth-perihelion {
-  color: hsl(168 60% 62%);
-}
-.almanac-badge--moon-apogee,
-.almanac-badge--moon-perigee {
-  border-color: hsl(var(--muted-foreground) / 0.35);
-  background: hsl(var(--muted-foreground) / 0.08);
-  color: hsl(var(--muted-foreground));
-}
-
-.almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--moon-planet-conjunction,
 .dark .almanac-badge--planetary-conjunction {
   color: hsl(200 85% 72%);
-}
-
-.almanac-badge--march-equinox,
-.almanac-badge--june-solstice,
-.almanac-badge--september-equinox,
-.almanac-badge--december-solstice {
-  border-color: rgba(217, 143, 12, 0.5);
-  background: rgba(253, 184, 19, 0.18);
-  color: #8a5a08;
-}
-
-.dark .almanac-badge--earth-aphelion,
-.almanac-badge--earth-perihelion {
-  border-color: hsl(168 60% 38% / 0.5);
-  background: hsl(168 60% 38% / 0.12);
-  color: hsl(168 70% 27%);
-}
-
-.dark .almanac-badge--earth-aphelion,
-.dark .almanac-badge--earth-perihelion {
-  color: hsl(168 60% 62%);
-}
-
-.almanac-badge--moon-apogee,
-.almanac-badge--moon-perigee {
-  border-color: hsl(var(--muted-foreground) / 0.35);
-  background: hsl(var(--muted-foreground) / 0.08);
-  color: hsl(var(--muted-foreground));
-}
-
-.almanac-badge--moon-planet-conjunction,
-.almanac-badge--planetary-conjunction {
-  border-color: hsl(200 70% 45% / 0.5);
-  background: hsl(200 70% 45% / 0.12);
-  color: hsl(200 75% 32%);
-}
-
-.dark .almanac-badge--earth-aphelion,
-.almanac-badge--earth-perihelion {
-  border-color: hsl(168 60% 38% / 0.5);
-  background: hsl(168 60% 38% / 0.12);
-  color: hsl(168 70% 27%);
-}
-
-.dark .almanac-badge--earth-aphelion,
-.dark .almanac-badge--earth-perihelion {
-  color: hsl(168 60% 62%);
-}
-
-.almanac-badge--moon-apogee,
-.almanac-badge--moon-perigee {
-  border-color: hsl(var(--muted-foreground) / 0.35);
-  background: hsl(var(--muted-foreground) / 0.08);
-  color: hsl(var(--muted-foreground));
-}
-
-.almanac-badge--moon-planet-conjunction,
-.dark .almanac-badge--planetary-conjunction {
-  color: hsl(200 85% 72%);
-}
-
-.almanac-badge--march-equinox,
-.dark .almanac-badge--june-solstice,
-.dark .almanac-badge--september-equinox,
-.dark .almanac-badge--december-solstice {
-  color: #f0b429;
 }
 
 @media (max-width: 768px) {
   .almanac-apsis-strip {
     padding-left: 0;
     border-left: none;
+  }
+
+  .almanac-event-time {
+    margin-left: 0;
+    width: 3.25rem;
+    text-align: center;
+    font-size: 0.85rem;
   }
 
   .almanac-board {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -770,6 +770,18 @@ h1, h2, h3 {
   color: #e08a63;
 }
 
+.almanac-badge--moon-planet-conjunction,
+.almanac-badge--planetary-conjunction {
+  border-color: hsl(200 70% 45% / 0.5);
+  background: hsl(200 70% 45% / 0.12);
+  color: hsl(200 75% 32%);
+}
+
+.dark .almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--planetary-conjunction {
+  color: hsl(200 85% 72%);
+}
+
 .almanac-badge--march-equinox,
 .almanac-badge--june-solstice,
 .almanac-badge--september-equinox,
@@ -779,7 +791,19 @@ h1, h2, h3 {
   color: #8a5a08;
 }
 
-.dark .almanac-badge--march-equinox,
+.dark .almanac-badge--moon-planet-conjunction,
+.almanac-badge--planetary-conjunction {
+  border-color: hsl(200 70% 45% / 0.5);
+  background: hsl(200 70% 45% / 0.12);
+  color: hsl(200 75% 32%);
+}
+
+.dark .almanac-badge--moon-planet-conjunction,
+.dark .almanac-badge--planetary-conjunction {
+  color: hsl(200 85% 72%);
+}
+
+.almanac-badge--march-equinox,
 .dark .almanac-badge--june-solstice,
 .dark .almanac-badge--september-equinox,
 .dark .almanac-badge--december-solstice {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -712,13 +712,33 @@ h1, h2, h3 {
   color: hsl(240 90% 82%);
 }
 
+.almanac-badge--lunar-eclipse {
+  border-color: rgba(156, 69, 38, 0.6);
+  background: rgba(156, 69, 38, 0.15);
+  color: #8a3a22;
+}
+
+.dark .almanac-badge--lunar-eclipse {
+  color: #e08a63;
+}
+
 .almanac-badge--greatest-elongation {
   border-color: hsl(var(--accent) / 0.5);
   background: hsl(var(--accent) / 0.12);
   color: hsl(280 55% 42%);
 }
 
-.dark .almanac-badge--greatest-elongation {
+.dark .almanac-badge--lunar-eclipse {
+  border-color: rgba(156, 69, 38, 0.6);
+  background: rgba(156, 69, 38, 0.15);
+  color: #8a3a22;
+}
+
+.dark .almanac-badge--lunar-eclipse {
+  color: #e08a63;
+}
+
+.almanac-badge--greatest-elongation {
   color: hsl(280 90% 80%);
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -606,8 +606,46 @@ h1, h2, h3 {
   margin-top: 1.75rem;
 }
 
+.almanac-month-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1.5rem;
+  padding-bottom: 0.35rem;
+}
+
+.almanac-phase-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.almanac-phase {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.almanac-phase-glyph {
+  font-size: 0.95rem;
+  line-height: 1;
+  filter: drop-shadow(0 0 5px hsl(var(--accent) / 0.3));
+}
+
+.almanac-phase-day {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  color: hsl(var(--muted-foreground));
+}
+
 .almanac-month-label {
-  margin-bottom: 0.25rem;
+  margin-bottom: 0;
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.16em;

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -8,7 +8,7 @@ class AlmanacController < ApplicationController
     @events_by_month = group_by_month(@events)
     @moon_phases_by_month = group_by_month(lunar_rhythm(:moon_phases))
     @moon_apsides_by_month = group_by_month(lunar_rhythm(:moon_apsides))
-    @months = (@events_by_month.keys | upcoming_phase_months).sort
+    @months = (@events_by_month.keys | upcoming_rhythm_months).sort
 
     track_page_view("almanac")
   end
@@ -26,9 +26,14 @@ class AlmanacController < ApplicationController
       .chronological
   end
 
-  def upcoming_phase_months
-    @moon_phases_by_month
-      .select { |_, phases| phases.any? { |phase| phase.peak_at >= @time } }
+  def upcoming_rhythm_months
+    upcoming_months(@moon_phases_by_month) |
+      upcoming_months(@moon_apsides_by_month)
+  end
+
+  def upcoming_months(events_by_month)
+    events_by_month
+      .select { |_, events| events.any? { |event| event.peak_at >= @time } }
       .keys
   end
 

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -7,7 +7,7 @@ class AlmanacController < ApplicationController
     @events = notable_events
     @events_by_month = group_by_month(@events)
     @moon_phases_by_month = group_by_month(moon_phases)
-    @months = (@events_by_month.keys | @moon_phases_by_month.keys).sort
+    @months = (@events_by_month.keys | upcoming_phase_months).sort
 
     track_page_view("almanac")
   end
@@ -23,6 +23,12 @@ class AlmanacController < ApplicationController
       .moon_phases
       .between(@time.beginning_of_month, (@time + LOOKAHEAD).end_of_month)
       .chronological
+  end
+
+  def upcoming_phase_months
+    @moon_phases_by_month
+      .select { |_, phases| phases.any? { |phase| phase.peak_at >= @time } }
+      .keys
   end
 
   def group_by_month(scope)

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class AlmanacController < ApplicationController
+  LOOKAHEAD = 1.year
+
   def show
+    @events = CelestialEvent
+      .between(@time, @time + LOOKAHEAD)
+      .chronological
+    @events_by_month = @events
+      .group_by { |event| event.peak_at.in_time_zone.beginning_of_month }
+
     track_page_view("almanac")
   end
 end

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AlmanacController < ApplicationController
+  def show
+    track_page_view("almanac")
+  end
+end

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -9,6 +9,7 @@ class AlmanacController < ApplicationController
     @moon_phases_by_month = group_by_month(lunar_rhythm(:moon_phases))
     @moon_apsides_by_month = group_by_month(lunar_rhythm(:moon_apsides))
     @months = (@events_by_month.keys | upcoming_rhythm_months).sort
+    @event_count = shown_event_count
 
     track_page_view("almanac")
   end
@@ -16,14 +17,21 @@ class AlmanacController < ApplicationController
   private
 
   def notable_events
-    CelestialEvent.notable.between(@time, @time + LOOKAHEAD).chronological
+    CelestialEvent
+      .notable
+      .between(@time, horizon)
+      .chronological
   end
 
   def lunar_rhythm(scope)
     CelestialEvent
       .public_send(scope)
-      .between(@time.beginning_of_month, (@time + LOOKAHEAD).end_of_month)
+      .between(@time.beginning_of_month, horizon)
       .chronological
+  end
+
+  def horizon
+    (@time + LOOKAHEAD).end_of_month
   end
 
   def upcoming_rhythm_months
@@ -35,6 +43,11 @@ class AlmanacController < ApplicationController
     events_by_month
       .select { |_, events| events.any? { |event| event.peak_at >= @time } }
       .keys
+  end
+
+  def shown_event_count
+    [@events_by_month, @moon_phases_by_month, @moon_apsides_by_month]
+      .sum { |by_month| @months.sum { |month| by_month.fetch(month, []).size } }
   end
 
   def group_by_month(scope)

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -4,12 +4,28 @@ class AlmanacController < ApplicationController
   LOOKAHEAD = 1.year
 
   def show
-    @events = CelestialEvent
-      .between(@time, @time + LOOKAHEAD)
-      .chronological
-    @events_by_month = @events
-      .group_by { |event| event.peak_at.in_time_zone.beginning_of_month }
+    @events = notable_events
+    @events_by_month = group_by_month(@events)
+    @moon_phases_by_month = group_by_month(moon_phases)
+    @months = (@events_by_month.keys | @moon_phases_by_month.keys).sort
 
     track_page_view("almanac")
+  end
+
+  private
+
+  def notable_events
+    CelestialEvent.notable.between(@time, @time + LOOKAHEAD).chronological
+  end
+
+  def moon_phases
+    CelestialEvent
+      .moon_phases
+      .between(@time.beginning_of_month, (@time + LOOKAHEAD).end_of_month)
+      .chronological
+  end
+
+  def group_by_month(scope)
+    scope.group_by { |event| event.peak_at.in_time_zone.beginning_of_month }
   end
 end

--- a/app/controllers/almanac_controller.rb
+++ b/app/controllers/almanac_controller.rb
@@ -6,7 +6,8 @@ class AlmanacController < ApplicationController
   def show
     @events = notable_events
     @events_by_month = group_by_month(@events)
-    @moon_phases_by_month = group_by_month(moon_phases)
+    @moon_phases_by_month = group_by_month(lunar_rhythm(:moon_phases))
+    @moon_apsides_by_month = group_by_month(lunar_rhythm(:moon_apsides))
     @months = (@events_by_month.keys | upcoming_phase_months).sort
 
     track_page_view("almanac")
@@ -18,9 +19,9 @@ class AlmanacController < ApplicationController
     CelestialEvent.notable.between(@time, @time + LOOKAHEAD).chronological
   end
 
-  def moon_phases
+  def lunar_rhythm(scope)
     CelestialEvent
-      .moon_phases
+      .public_send(scope)
       .between(@time.beginning_of_month, (@time + LOOKAHEAD).end_of_month)
       .chronological
   end

--- a/app/helpers/celestial_event_helper.rb
+++ b/app/helpers/celestial_event_helper.rb
@@ -5,6 +5,7 @@ module CelestialEventHelper
     I18n.t(
       "almanac.show.kinds.#{event.kind}.title",
       body: celestial_event_body_name(event),
+      secondary_body: celestial_event_secondary_body_name(event),
       date: I18n.l(event.peak_at.in_time_zone.to_date, format: :long)
     )
   end
@@ -14,8 +15,16 @@ module CelestialEventHelper
   end
 
   def celestial_event_body_name(event)
-    return if event.primary_body.blank?
+    planet_name(event.primary_body)
+  end
 
-    I18n.t("models.planets.#{event.primary_body.downcase}.name")
+  def celestial_event_secondary_body_name(event)
+    planet_name(event.secondary_body)
+  end
+
+  def planet_name(body)
+    return if body.blank?
+
+    I18n.t("models.planets.#{body.downcase}.name")
   end
 end

--- a/app/helpers/celestial_event_helper.rb
+++ b/app/helpers/celestial_event_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CelestialEventHelper
+  def celestial_event_title(event)
+    I18n.t(
+      "almanac.show.kinds.#{event.kind}.title",
+      body: celestial_event_body_name(event)
+    )
+  end
+
+  def celestial_event_kind_name(event)
+    I18n.t("almanac.show.kinds.#{event.kind}.name")
+  end
+
+  def celestial_event_body_name(event)
+    I18n.t("models.planets.#{event.primary_body.to_s.downcase}.name")
+  end
+end

--- a/app/helpers/celestial_event_helper.rb
+++ b/app/helpers/celestial_event_helper.rb
@@ -4,7 +4,8 @@ module CelestialEventHelper
   def celestial_event_title(event)
     I18n.t(
       "almanac.show.kinds.#{event.kind}.title",
-      body: celestial_event_body_name(event)
+      body: celestial_event_body_name(event),
+      date: I18n.l(event.peak_at.in_time_zone.to_date, format: :long)
     )
   end
 
@@ -13,6 +14,8 @@ module CelestialEventHelper
   end
 
   def celestial_event_body_name(event)
-    I18n.t("models.planets.#{event.primary_body.to_s.downcase}.name")
+    return if event.primary_body.blank?
+
+    I18n.t("models.planets.#{event.primary_body.downcase}.name")
   end
 end

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -3,7 +3,7 @@
 class CelestialEvent < ApplicationRecord
   KINDS = [
     OPPOSITION = "opposition",
-    MAXIMUM_ELONGATION = "maximum_elongation"
+    GREATEST_ELONGATION = "greatest_elongation"
   ].freeze
 
   validates :kind, presence: true, inclusion: {in: KINDS}

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -1,5 +1,7 @@
 class CelestialEvent < ApplicationRecord
-  validates :kind, presence: true
+  KINDS = %w[opposition greatest_elongation].freeze
+
+  validates :kind, presence: true, inclusion: {in: KINDS}
   validates :peak_tt, presence: true
   validates :peak_at, presence: true
 

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -1,0 +1,24 @@
+class CelestialEvent < ApplicationRecord
+  validates :kind, presence: true
+  validates :peak_tt, presence: true
+  validates :peak_at, presence: true
+
+  before_validation(
+    :set_peak_at,
+    if: -> { peak_tt.present? && peak_tt_changed? }
+  )
+
+  scope :between, ->(from, to) { where(peak_at: from..to) }
+  scope :of_kind, ->(kinds) { where(kind: kinds) if kinds.present? }
+  scope :chronological, -> { order(:peak_at) }
+
+  def instant
+    Astronoby::Instant.from_terrestrial_time(peak_tt)
+  end
+
+  private
+
+  def set_peak_at
+    self.peak_at = instant.to_time
+  end
+end

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -10,12 +10,21 @@ class CelestialEvent < ApplicationRecord
     LAST_QUARTER = "last_quarter",
     LUNAR_ECLIPSE = "lunar_eclipse",
     MARCH_EQUINOX = "march_equinox",
+    MOON_PLANET_CONJUNCTION = "moon_planet_conjunction",
     NEW_MOON = "new_moon",
     OPPOSITION = "opposition",
+    PLANETARY_CONJUNCTION = "planetary_conjunction",
     SEPTEMBER_EQUINOX = "september_equinox"
   ].freeze
 
-  KINDS_WITH_BODY = [GREATEST_ELONGATION, OPPOSITION].freeze
+  KINDS_WITH_BODY = [
+    GREATEST_ELONGATION,
+    MOON_PLANET_CONJUNCTION,
+    OPPOSITION,
+    PLANETARY_CONJUNCTION
+  ].freeze
+
+  KINDS_WITH_SECONDARY_BODY = [PLANETARY_CONJUNCTION].freeze
 
   SEASON_KINDS = [
     MARCH_EQUINOX,
@@ -35,6 +44,9 @@ class CelestialEvent < ApplicationRecord
   validates :primary_body,
     presence: true,
     if: -> { KINDS_WITH_BODY.include?(kind) }
+  validates :secondary_body,
+    presence: true,
+    if: -> { KINDS_WITH_SECONDARY_BODY.include?(kind) }
   validates :peak_tt, presence: true
   validates :peak_at, presence: true
 

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -16,7 +16,7 @@ class CelestialEvent < ApplicationRecord
   )
 
   scope :between, ->(from, to) { where(peak_at: from..to) }
-  scope :of_kind, ->(kinds) { where(kind: kinds) if kinds.present? }
+  scope :of_kind, ->(kinds) { where(kind: kinds) }
   scope :chronological, -> { order(:peak_at) }
 
   def instant

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -2,11 +2,17 @@
 
 class CelestialEvent < ApplicationRecord
   KINDS = [
-    OPPOSITION = "opposition",
-    GREATEST_ELONGATION = "greatest_elongation"
+    GREATEST_ELONGATION = "greatest_elongation",
+    LUNAR_ECLIPSE = "lunar_eclipse",
+    OPPOSITION = "opposition"
   ].freeze
 
+  KINDS_WITH_BODY = [GREATEST_ELONGATION, OPPOSITION].freeze
+
   validates :kind, presence: true, inclusion: {in: KINDS}
+  validates :primary_body,
+    presence: true,
+    if: -> { KINDS_WITH_BODY.include?(kind) }
   validates :peak_tt, presence: true
   validates :peak_at, presence: true
 

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -3,6 +3,8 @@
 class CelestialEvent < ApplicationRecord
   KINDS = [
     DECEMBER_SOLSTICE = "december_solstice",
+    EARTH_APHELION = "earth_aphelion",
+    EARTH_PERIHELION = "earth_perihelion",
     FIRST_QUARTER = "first_quarter",
     FULL_MOON = "full_moon",
     GREATEST_ELONGATION = "greatest_elongation",
@@ -10,6 +12,8 @@ class CelestialEvent < ApplicationRecord
     LAST_QUARTER = "last_quarter",
     LUNAR_ECLIPSE = "lunar_eclipse",
     MARCH_EQUINOX = "march_equinox",
+    MOON_APOGEE = "moon_apogee",
+    MOON_PERIGEE = "moon_perigee",
     MOON_PLANET_CONJUNCTION = "moon_planet_conjunction",
     NEW_MOON = "new_moon",
     OPPOSITION = "opposition",
@@ -40,6 +44,9 @@ class CelestialEvent < ApplicationRecord
     LAST_QUARTER
   ].freeze
 
+  MOON_APSIS_KINDS = [MOON_PERIGEE, MOON_APOGEE].freeze
+  LUNAR_RHYTHM_KINDS = (MOON_PHASE_KINDS + MOON_APSIS_KINDS).freeze
+
   validates :kind, presence: true, inclusion: {in: KINDS}
   validates :primary_body,
     presence: true,
@@ -57,7 +64,8 @@ class CelestialEvent < ApplicationRecord
 
   scope :between, ->(from, to) { where(peak_at: from..to) }
   scope :moon_phases, -> { where(kind: MOON_PHASE_KINDS) }
-  scope :notable, -> { where.not(kind: MOON_PHASE_KINDS) }
+  scope :moon_apsides, -> { where(kind: MOON_APSIS_KINDS) }
+  scope :notable, -> { where.not(kind: LUNAR_RHYTHM_KINDS) }
   scope :of_kind, ->(kinds) { where(kind: kinds) }
   scope :chronological, -> { order(:peak_at) }
 

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -2,12 +2,23 @@
 
 class CelestialEvent < ApplicationRecord
   KINDS = [
+    FIRST_QUARTER = "first_quarter",
+    FULL_MOON = "full_moon",
     GREATEST_ELONGATION = "greatest_elongation",
+    LAST_QUARTER = "last_quarter",
     LUNAR_ECLIPSE = "lunar_eclipse",
+    NEW_MOON = "new_moon",
     OPPOSITION = "opposition"
   ].freeze
 
   KINDS_WITH_BODY = [GREATEST_ELONGATION, OPPOSITION].freeze
+
+  MOON_PHASE_KINDS = [
+    NEW_MOON,
+    FIRST_QUARTER,
+    FULL_MOON,
+    LAST_QUARTER
+  ].freeze
 
   validates :kind, presence: true, inclusion: {in: KINDS}
   validates :primary_body,
@@ -22,6 +33,8 @@ class CelestialEvent < ApplicationRecord
   )
 
   scope :between, ->(from, to) { where(peak_at: from..to) }
+  scope :moon_phases, -> { where(kind: MOON_PHASE_KINDS) }
+  scope :notable, -> { where.not(kind: MOON_PHASE_KINDS) }
   scope :of_kind, ->(kinds) { where(kind: kinds) }
   scope :chronological, -> { order(:peak_at) }
 

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -1,5 +1,10 @@
+# frozen_string_literal: true
+
 class CelestialEvent < ApplicationRecord
-  KINDS = %w[opposition greatest_elongation].freeze
+  KINDS = [
+    OPPOSITION = "opposition",
+    MAXIMUM_ELONGATION = "maximum_elongation"
+  ].freeze
 
   validates :kind, presence: true, inclusion: {in: KINDS}
   validates :peak_tt, presence: true

--- a/app/models/celestial_event.rb
+++ b/app/models/celestial_event.rb
@@ -2,16 +2,27 @@
 
 class CelestialEvent < ApplicationRecord
   KINDS = [
+    DECEMBER_SOLSTICE = "december_solstice",
     FIRST_QUARTER = "first_quarter",
     FULL_MOON = "full_moon",
     GREATEST_ELONGATION = "greatest_elongation",
+    JUNE_SOLSTICE = "june_solstice",
     LAST_QUARTER = "last_quarter",
     LUNAR_ECLIPSE = "lunar_eclipse",
+    MARCH_EQUINOX = "march_equinox",
     NEW_MOON = "new_moon",
-    OPPOSITION = "opposition"
+    OPPOSITION = "opposition",
+    SEPTEMBER_EQUINOX = "september_equinox"
   ].freeze
 
   KINDS_WITH_BODY = [GREATEST_ELONGATION, OPPOSITION].freeze
+
+  SEASON_KINDS = [
+    MARCH_EQUINOX,
+    JUNE_SOLSTICE,
+    SEPTEMBER_EQUINOX,
+    DECEMBER_SOLSTICE
+  ].freeze
 
   MOON_PHASE_KINDS = [
     NEW_MOON,

--- a/app/models/celestial_events/close_approaches.rb
+++ b/app/models/celestial_events/close_approaches.rb
@@ -24,7 +24,15 @@ module CelestialEvents
           here.first if before.last > here.last && here.last <= after.last
         end
         .map { |time| approach_at(primary, secondary, time) }
-        .select { |approach| approach.separation <= MAX_APPROACH_SEPARATION }
+        .select { |approach| near_pass?(approach) && covered?(approach.time) }
+    end
+
+    def near_pass?(approach)
+      approach.separation <= MAX_APPROACH_SEPARATION
+    end
+
+    def covered?(time)
+      time.between?(@start_date, @end_date)
     end
 
     def separation_samples(primary, secondary)
@@ -32,8 +40,9 @@ module CelestialEvents
     end
 
     def sample_times
-      steps = ((@end_date - @start_date) / SAMPLE_STEP).ceil
-      (0..steps).map { |step| @start_date + (step * SAMPLE_STEP) }
+      steps = ((@end_date - @start_date) / SAMPLE_STEP).ceil + 2
+      first_sample = @start_date - SAMPLE_STEP
+      (0..steps).map { |step| first_sample + (step * SAMPLE_STEP) }
     end
 
     def approach_at(primary, secondary, sampled_time)

--- a/app/models/celestial_events/close_approaches.rb
+++ b/app/models/celestial_events/close_approaches.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  module CloseApproaches
+    MAX_APPROACH_SEPARATION = Astronoby::Angle.from_degrees(15)
+    SAMPLE_STEP = 1.day
+    REFINEMENT_WINDOW = 1.day
+    REFINEMENT_ITERATIONS = 30
+
+    Approach = Struct.new(
+      :primary,
+      :secondary,
+      :time,
+      :separation,
+      :solar_elongation
+    )
+
+    private
+
+    def close_approaches(primary, secondary)
+      separation_samples(primary, secondary)
+        .each_cons(3)
+        .filter_map do |before, here, after|
+          here.first if before.last > here.last && here.last <= after.last
+        end
+        .map { |time| approach_at(primary, secondary, time) }
+        .select { |approach| approach.separation <= MAX_APPROACH_SEPARATION }
+    end
+
+    def separation_samples(primary, secondary)
+      sample_times.map { |time| [time, separation(primary, secondary, time)] }
+    end
+
+    def sample_times
+      steps = ((@end_date - @start_date) / SAMPLE_STEP).ceil
+      (0..steps).map { |step| @start_date + (step * SAMPLE_STEP) }
+    end
+
+    def approach_at(primary, secondary, sampled_time)
+      time = closest_approach(primary, secondary, sampled_time)
+
+      Approach.new(
+        primary,
+        secondary,
+        time,
+        separation(primary, secondary, time),
+        solar_elongation(primary, secondary, time)
+      )
+    end
+
+    def closest_approach(primary, secondary, time)
+      low = time - REFINEMENT_WINDOW
+      high = time + REFINEMENT_WINDOW
+
+      REFINEMENT_ITERATIONS.times do
+        first = low + ((high - low) / 3)
+        second = high - ((high - low) / 3)
+
+        if separation(primary, secondary, first) <
+            separation(primary, secondary, second)
+          high = second
+        else
+          low = first
+        end
+      end
+
+      low + ((high - low) / 2)
+    end
+
+    def separation(primary, secondary, time)
+      apparent(primary, time).separation_from(apparent(secondary, time))
+    end
+
+    def solar_elongation(primary, secondary, time)
+      [elongation(primary, time), elongation(secondary, time)].min
+    end
+
+    def elongation(body, time)
+      apparent(body, time).separation_from(apparent(Astronoby::Sun, time))
+    end
+
+    def apparent(body, time)
+      body_at(body, time).apparent
+    end
+
+    def magnitude(body, time)
+      body_at(body, time).apparent_magnitude
+    end
+
+    def body_at(body, time)
+      body.new(
+        instant: Astronoby::Instant.from_time(time),
+        ephem: SPK.inpop19a
+      )
+    end
+  end
+end

--- a/app/models/celestial_events/earth_aphelia_perihelia_generator.rb
+++ b/app/models/celestial_events/earth_aphelia_perihelia_generator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class EarthApheliaPeriheliaGenerator
+    ApsisEvent = Struct.new(:kind, :instant)
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |apsis_event|
+        CelestialEvent.create!(
+          kind: apsis_event.kind,
+          peak_tt: apsis_event.instant.tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      aphelia + perihelia
+    end
+
+    def aphelia
+      apsides(:apoapsis_events_between, CelestialEvent::EARTH_APHELION)
+    end
+
+    def perihelia
+      apsides(:periapsis_events_between, CelestialEvent::EARTH_PERIHELION)
+    end
+
+    def apsides(event_type, kind)
+      extremum_calculator
+        .public_send(event_type, @start_date, @end_date)
+        .map { |event| ApsisEvent.new(kind, event.instant) }
+    end
+
+    def extremum_calculator
+      @extremum_calculator ||= Astronoby::ExtremumCalculator.new(
+        body: Earth.planet_class,
+        primary_body: Sun.planet_class,
+        ephem: SPK.inpop19a
+      )
+    end
+  end
+end

--- a/app/models/celestial_events/equinoxes_solstices_generator.rb
+++ b/app/models/celestial_events/equinoxes_solstices_generator.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class EquinoxesSolsticesGenerator
+    SeasonEvent = Struct.new(:kind, :time)
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |season_event|
+        CelestialEvent.create!(
+          kind: season_event.kind,
+          peak_tt: Astronoby::Instant.from_time(season_event.time).tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      years
+        .flat_map { |year| generate_seasons_for_year(year) }
+        .select { |season_event| covered?(season_event.time) }
+    end
+
+    def generate_seasons_for_year(year)
+      CelestialEvent::SEASON_KINDS.map do |kind|
+        SeasonEvent.new(kind, season_time(kind, year))
+      end
+    end
+
+    def season_time(kind, year)
+      Astronoby::EquinoxSolstice.public_send(kind, year, SPK.inpop19a)
+    end
+
+    def years
+      (@start_date.year..@end_date.year)
+    end
+
+    def covered?(time)
+      time.between?(@start_date, @end_date)
+    end
+  end
+end

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -3,13 +3,15 @@
 module CelestialEvents
   class Generator
     EVENT_TYPES = [
-      OPPOSITIONS = :oppositions,
-      GREATEST_ELONGATIONS = :greatest_elongations
+      GREATEST_ELONGATIONS = :greatest_elongations,
+      LUNAR_ECLIPSES = :lunar_eclipses,
+      OPPOSITIONS = :oppositions
     ].freeze
 
     GENERATORS = {
-      OPPOSITIONS => OppositionsGenerator,
-      GREATEST_ELONGATIONS => GreatestElongationsGenerator
+      GREATEST_ELONGATIONS => GreatestElongationsGenerator,
+      LUNAR_ECLIPSES => LunarEclipsesGenerator,
+      OPPOSITIONS => OppositionsGenerator
     }.freeze
 
     def initialize(start_date, end_date)

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -7,7 +7,9 @@ module CelestialEvents
       GREATEST_ELONGATIONS = :greatest_elongations,
       LUNAR_ECLIPSES = :lunar_eclipses,
       MOON_PHASES = :moon_phases,
-      OPPOSITIONS = :oppositions
+      MOON_PLANET_CONJUNCTIONS = :moon_planet_conjunctions,
+      OPPOSITIONS = :oppositions,
+      PLANETARY_CONJUNCTIONS = :planetary_conjunctions
     ].freeze
 
     GENERATORS = {
@@ -15,7 +17,9 @@ module CelestialEvents
       GREATEST_ELONGATIONS => GreatestElongationsGenerator,
       LUNAR_ECLIPSES => LunarEclipsesGenerator,
       MOON_PHASES => MoonPhasesGenerator,
-      OPPOSITIONS => OppositionsGenerator
+      MOON_PLANET_CONJUNCTIONS => MoonPlanetConjunctionsGenerator,
+      OPPOSITIONS => OppositionsGenerator,
+      PLANETARY_CONJUNCTIONS => PlanetaryConjunctionsGenerator
     }.freeze
 
     def initialize(start_date, end_date)

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -5,12 +5,14 @@ module CelestialEvents
     EVENT_TYPES = [
       GREATEST_ELONGATIONS = :greatest_elongations,
       LUNAR_ECLIPSES = :lunar_eclipses,
+      MOON_PHASES = :moon_phases,
       OPPOSITIONS = :oppositions
     ].freeze
 
     GENERATORS = {
       GREATEST_ELONGATIONS => GreatestElongationsGenerator,
       LUNAR_ECLIPSES => LunarEclipsesGenerator,
+      MOON_PHASES => MoonPhasesGenerator,
       OPPOSITIONS => OppositionsGenerator
     }.freeze
 

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -3,11 +3,13 @@
 module CelestialEvents
   class Generator
     EVENT_TYPES = [
-      OPPOSITIONS = :oppositions
+      OPPOSITIONS = :oppositions,
+      GREATEST_ELONGATIONS = :greatest_elongations
     ].freeze
 
     GENERATORS = {
-      OPPOSITIONS => OppositionsGenerator
+      OPPOSITIONS => OppositionsGenerator,
+      GREATEST_ELONGATIONS => GreatestElongationsGenerator
     }.freeze
 
     def initialize(start_date, end_date)

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -3,6 +3,7 @@
 module CelestialEvents
   class Generator
     EVENT_TYPES = [
+      EQUINOXES_SOLSTICES = :equinoxes_solstices,
       GREATEST_ELONGATIONS = :greatest_elongations,
       LUNAR_ECLIPSES = :lunar_eclipses,
       MOON_PHASES = :moon_phases,
@@ -10,6 +11,7 @@ module CelestialEvents
     ].freeze
 
     GENERATORS = {
+      EQUINOXES_SOLSTICES => EquinoxesSolsticesGenerator,
       GREATEST_ELONGATIONS => GreatestElongationsGenerator,
       LUNAR_ECLIPSES => LunarEclipsesGenerator,
       MOON_PHASES => MoonPhasesGenerator,

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -10,25 +10,30 @@ module CelestialEvents
       OPPOSITIONS => OppositionsGenerator
     }.freeze
 
-    def initialize(event_type, start_date, end_date)
-      @event_type = event_type
+    def initialize(start_date, end_date)
       @start_date = start_date
       @end_date = end_date
     end
 
-    def generate
-      ensure_event_type!
+    def generate_all
+      EVENT_TYPES.each do |event_type|
+        generate(event_type)
+      end
+    end
 
-      generator_class = GENERATORS[@event_type]
+    def generate(event_type)
+      ensure_event_type!(event_type)
+
+      generator_class = GENERATORS[event_type]
       generator = generator_class.new(@start_date, @end_date)
       generator.generate
     end
 
     private
 
-    def ensure_event_type!
-      unless EVENT_TYPES.include?(@event_type)
-        raise ArgumentError, "Unsupported event type: #{@event_type}"
+    def ensure_event_type!(event_type)
+      unless EVENT_TYPES.include?(event_type)
+        raise ArgumentError, "Unsupported event type: #{event_type}"
       end
     end
   end

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -3,9 +3,11 @@
 module CelestialEvents
   class Generator
     EVENT_TYPES = [
+      EARTH_APHELIA_PERIHELIA = :earth_aphelia_perihelia,
       EQUINOXES_SOLSTICES = :equinoxes_solstices,
       GREATEST_ELONGATIONS = :greatest_elongations,
       LUNAR_ECLIPSES = :lunar_eclipses,
+      MOON_APOGEES_PERIGEES = :moon_apogees_perigees,
       MOON_PHASES = :moon_phases,
       MOON_PLANET_CONJUNCTIONS = :moon_planet_conjunctions,
       OPPOSITIONS = :oppositions,
@@ -13,13 +15,15 @@ module CelestialEvents
     ].freeze
 
     GENERATORS = {
+      EARTH_APHELIA_PERIHELIA => EarthApheliaPeriheliaGenerator,
       EQUINOXES_SOLSTICES => EquinoxesSolsticesGenerator,
       GREATEST_ELONGATIONS => GreatestElongationsGenerator,
       LUNAR_ECLIPSES => LunarEclipsesGenerator,
       MOON_PHASES => MoonPhasesGenerator,
       MOON_PLANET_CONJUNCTIONS => MoonPlanetConjunctionsGenerator,
       OPPOSITIONS => OppositionsGenerator,
-      PLANETARY_CONJUNCTIONS => PlanetaryConjunctionsGenerator
+      PLANETARY_CONJUNCTIONS => PlanetaryConjunctionsGenerator,
+      MOON_APOGEES_PERIGEES => MoonApogeesPerigeesGenerator
     }.freeze
 
     def initialize(start_date, end_date)

--- a/app/models/celestial_events/generator.rb
+++ b/app/models/celestial_events/generator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class Generator
+    EVENT_TYPES = [
+      OPPOSITIONS = :oppositions
+    ].freeze
+
+    GENERATORS = {
+      OPPOSITIONS => OppositionsGenerator
+    }.freeze
+
+    def initialize(event_type, start_date, end_date)
+      @event_type = event_type
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      ensure_event_type!
+
+      generator_class = GENERATORS[@event_type]
+      generator = generator_class.new(@start_date, @end_date)
+      generator.generate
+    end
+
+    private
+
+    def ensure_event_type!
+      unless EVENT_TYPES.include?(@event_type)
+        raise ArgumentError, "Unsupported event type: #{@event_type}"
+      end
+    end
+  end
+end

--- a/app/models/celestial_events/greatest_elongations_generator.rb
+++ b/app/models/celestial_events/greatest_elongations_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class GreatestElongationsGenerator
+    PLANETS = %w[Mercury Venus].freeze
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |greatest_elongation|
+        CelestialEvent.create!(
+          kind: CelestialEvent::GREATEST_ELONGATION,
+          primary_body: greatest_elongation.body.name.demodulize,
+          peak_tt: greatest_elongation.instant.tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      PLANETS.each_with_object([]) do |planet, events|
+        events.concat(generate_greatest_elongations_for_planet(planet))
+      end
+    end
+
+    def generate_greatest_elongations_for_planet(planet)
+      "Astronoby::#{planet}".constantize.greatest_elongation_events(
+        ephem: SPK.inpop19a,
+        start_time: @start_date,
+        end_time: @end_date
+      )
+    end
+  end
+end

--- a/app/models/celestial_events/lunar_eclipses_generator.rb
+++ b/app/models/celestial_events/lunar_eclipses_generator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class LunarEclipsesGenerator
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |lunar_eclipses|
+        CelestialEvent.create!(
+          kind: CelestialEvent::LUNAR_ECLIPSE,
+          peak_tt: lunar_eclipses.instant.tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      Astronoby::Moon.eclipse_events(
+        ephem: SPK.inpop19a,
+        start_time: @start_date,
+        end_time: @end_date
+      )
+    end
+  end
+end

--- a/app/models/celestial_events/moon_apogees_perigees_generator.rb
+++ b/app/models/celestial_events/moon_apogees_perigees_generator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class MoonApogeesPerigeesGenerator
+    ApsisEvent = Struct.new(:kind, :instant)
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |apsis_event|
+        CelestialEvent.create!(
+          kind: apsis_event.kind,
+          peak_tt: apsis_event.instant.tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      apogees + perigees
+    end
+
+    def apogees
+      apsides(:apoapsis_events, CelestialEvent::MOON_APOGEE)
+    end
+
+    def perigees
+      apsides(:periapsis_events, CelestialEvent::MOON_PERIGEE)
+    end
+
+    def apsides(event_type, kind)
+      Astronoby::Moon
+        .public_send(
+          event_type,
+          ephem: SPK.inpop19a,
+          start_time: @start_date,
+          end_time: @end_date
+        )
+        .map { |event| ApsisEvent.new(kind, event.instant) }
+    end
+  end
+end

--- a/app/models/celestial_events/moon_phases_generator.rb
+++ b/app/models/celestial_events/moon_phases_generator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class MoonPhasesGenerator
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |moon_phase|
+        CelestialEvent.create!(
+          kind: moon_phase.phase.to_s,
+          peak_tt: Astronoby::Instant.from_time(moon_phase.time).tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      months.flat_map { |month| generate_phases_for_month(month) }
+    end
+
+    def generate_phases_for_month(month)
+      Astronoby::Moon.monthly_phase_events(
+        year: month.year,
+        month: month.month
+      )
+    end
+
+    def months
+      month = @start_date.to_date.beginning_of_month
+      last_month = @end_date.to_date.beginning_of_month
+
+      [].tap do |months|
+        while month <= last_month
+          months << month
+          month = month.next_month
+        end
+      end
+    end
+  end
+end

--- a/app/models/celestial_events/moon_planet_conjunctions_generator.rb
+++ b/app/models/celestial_events/moon_planet_conjunctions_generator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class MoonPlanetConjunctionsGenerator
+    include CloseApproaches
+
+    PLANETS = %w[Mercury Venus Mars Jupiter Saturn].freeze
+    MINIMUM_SOLAR_ELONGATION = Astronoby::Angle.from_degrees(10)
+    MAXIMUM_MAGNITUDE = 1.5
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |approach|
+        CelestialEvent.create!(
+          kind: CelestialEvent::MOON_PLANET_CONJUNCTION,
+          primary_body: approach.secondary.name.demodulize,
+          peak_tt: Astronoby::Instant.from_time(approach.time).tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      planets
+        .flat_map { |planet| close_approaches(Astronoby::Moon, planet) }
+        .select { |approach| worthwhile?(approach) }
+    end
+
+    def worthwhile?(approach)
+      approach.solar_elongation >= MINIMUM_SOLAR_ELONGATION &&
+        magnitude(approach.secondary, approach.time) <= MAXIMUM_MAGNITUDE
+    end
+
+    def planets
+      PLANETS.map { |name| "Astronoby::#{name}".constantize }
+    end
+  end
+end

--- a/app/models/celestial_events/moon_planet_conjunctions_generator.rb
+++ b/app/models/celestial_events/moon_planet_conjunctions_generator.rb
@@ -6,7 +6,7 @@ module CelestialEvents
 
     PLANETS = %w[Mercury Venus Mars Jupiter Saturn].freeze
     MINIMUM_SOLAR_ELONGATION = Astronoby::Angle.from_degrees(10)
-    MAXIMUM_MAGNITUDE = 1.5
+    MAXIMUM_MAGNITUDE = 1.0
 
     def initialize(start_date, end_date)
       @start_date = start_date

--- a/app/models/celestial_events/oppositions_generator.rb
+++ b/app/models/celestial_events/oppositions_generator.rb
@@ -13,6 +13,7 @@ module CelestialEvents
       astronoby_events.each do |opposition|
         CelestialEvent.create!(
           kind: CelestialEvent::OPPOSITION,
+          primary_body: opposition.body.name.demodulize,
           peak_tt: opposition.instant.tt
         )
       end

--- a/app/models/celestial_events/oppositions_generator.rb
+++ b/app/models/celestial_events/oppositions_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class OppositionsGenerator
+    PLANETS = %w[Mars Jupiter Saturn Uranus Neptune].freeze
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |opposition|
+        CelestialEvent.create!(
+          kind: CelestialEvent::OPPOSITION,
+          peak_tt: opposition.instant.tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      PLANETS.each_with_object([]) do |planet, events|
+        events.concat(generate_oppositions_for_planet(planet))
+      end
+    end
+
+    def generate_oppositions_for_planet(planet)
+      "Astronoby::#{planet}".constantize.opposition_events(
+        ephem: SPK.inpop19a,
+        start_time: @start_date,
+        end_time: @end_date
+      )
+    end
+  end
+end

--- a/app/models/celestial_events/planetary_conjunctions_generator.rb
+++ b/app/models/celestial_events/planetary_conjunctions_generator.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module CelestialEvents
+  class PlanetaryConjunctionsGenerator
+    include CloseApproaches
+
+    PLANETS = %w[Mercury Venus Mars Jupiter Saturn].freeze
+    MAXIMUM_SEPARATION = Astronoby::Angle.from_degrees(5)
+    MINIMUM_SOLAR_ELONGATION = Astronoby::Angle.from_degrees(10)
+
+    def initialize(start_date, end_date)
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def generate
+      astronoby_events.each do |approach|
+        CelestialEvent.create!(
+          kind: CelestialEvent::PLANETARY_CONJUNCTION,
+          primary_body: approach.primary.name.demodulize,
+          secondary_body: approach.secondary.name.demodulize,
+          peak_tt: Astronoby::Instant.from_time(approach.time).tt
+        )
+      end
+    end
+
+    private
+
+    def astronoby_events
+      pairs
+        .flat_map { |primary, secondary| close_approaches(primary, secondary) }
+        .select { |approach| worthwhile?(approach) }
+    end
+
+    def worthwhile?(approach)
+      approach.separation <= MAXIMUM_SEPARATION &&
+        approach.solar_elongation >= MINIMUM_SOLAR_ELONGATION
+    end
+
+    def pairs
+      PLANETS.map { |name| "Astronoby::#{name}".constantize }.combination(2)
+    end
+  end
+end

--- a/app/views/almanac/_event.html.erb
+++ b/app/views/almanac/_event.html.erb
@@ -1,0 +1,24 @@
+<% peak_at = event.peak_at.in_time_zone %>
+<li class="almanac-event">
+  <div class="almanac-event-date" aria-hidden="true">
+    <span class="almanac-event-day"><%= peak_at.day %></span>
+    <span class="almanac-event-weekday">
+      <%= l peak_at.to_date, format: :abbreviated_day %>
+    </span>
+  </div>
+
+  <div class="almanac-event-body">
+    <span class="almanac-badge almanac-badge--<%= event.kind.dasherize %>">
+      <%= celestial_event_kind_name(event) %>
+    </span>
+
+    <p class="text-base font-bold mt-2 leading-tight">
+      <%= celestial_event_title(event) %>
+    </p>
+  </div>
+
+  <time class="almanac-event-time" datetime="<%= peak_at.iso8601 %>">
+    <span class="sr-only"><%= l peak_at.to_date, format: :long %></span>
+    <%= l peak_at, format: :hm %>
+  </time>
+</li>

--- a/app/views/almanac/_moon_apsis_strip.html.erb
+++ b/app/views/almanac/_moon_apsis_strip.html.erb
@@ -1,0 +1,19 @@
+<ul
+  class="almanac-apsis-strip"
+  aria-label="<%= t ".label", month: month_label %>"
+>
+  <% moon_apsides.each do |apsis| %>
+    <% peak_at = apsis.peak_at.in_time_zone %>
+    <li class="almanac-apsis">
+      <span class="almanac-apsis-label">
+        <%= celestial_event_kind_name(apsis) %>
+      </span>
+      <time class="almanac-apsis-day" datetime="<%= peak_at.iso8601 %>">
+        <span class="sr-only">
+          <%= l peak_at.to_date, format: :long %>
+        </span>
+        <%= peak_at.day %>
+      </time>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/almanac/_moon_phase_strip.html.erb
+++ b/app/views/almanac/_moon_phase_strip.html.erb
@@ -1,0 +1,19 @@
+<ul class="almanac-phase-strip" aria-label="<%= t ".label", month: month_label %>">
+  <% moon_phases.each do |moon_phase| %>
+    <% peak_at = moon_phase.peak_at.in_time_zone %>
+    <li
+      class="almanac-phase"
+      title="<%= t "moon.phases.#{moon_phase.kind}" %> - <%= l peak_at.to_date, format: :long %>"
+    >
+      <span class="almanac-phase-glyph" aria-hidden="true">
+        <%= t "moon.phase_emojis.#{moon_phase.kind}" %>
+      </span>
+      <time class="almanac-phase-day" datetime="<%= peak_at.iso8601 %>">
+        <span class="sr-only">
+          <%= t "moon.phases.#{moon_phase.kind}" %>,
+        </span>
+        <%= peak_at.day %>
+      </time>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/almanac/show.html.erb
+++ b/app/views/almanac/show.html.erb
@@ -31,13 +31,23 @@
               </time>
             </h3>
 
-            <% if @moon_phases_by_month[month].present? %>
-              <%= render(
-                "moon_phase_strip",
-                moon_phases: @moon_phases_by_month[month],
-                month_label: month_label
-              ) %>
-            <% end %>
+            <div class="almanac-rhythm">
+              <% if @moon_phases_by_month[month].present? %>
+                <%= render(
+                  "moon_phase_strip",
+                  moon_phases: @moon_phases_by_month[month],
+                  month_label: month_label
+                ) %>
+              <% end %>
+
+              <% if @moon_apsides_by_month[month].present? %>
+                <%= render(
+                  "moon_apsis_strip",
+                  moon_apsides: @moon_apsides_by_month[month],
+                  month_label: month_label
+                ) %>
+              <% end %>
+            </div>
           </div>
 
           <% if @events_by_month[month].present? %>

--- a/app/views/almanac/show.html.erb
+++ b/app/views/almanac/show.html.erb
@@ -1,0 +1,1 @@
+<% content_for :title, "#{t("title")} • #{t(".title")}" %>

--- a/app/views/almanac/show.html.erb
+++ b/app/views/almanac/show.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<% if @events.any? %>
+<% if @months.any? %>
   <section
     aria-labelledby="almanac-timeline-heading"
     class="rounded-lg border bg-card text-card-foreground shadow-sm cosmic-card"
@@ -21,19 +21,32 @@
     </h2>
 
     <div class="almanac-board">
-      <% @events_by_month.each do |month, events| %>
+      <% @months.each do |month| %>
+        <% month_label = l month.to_date, format: :month_year %>
         <div class="almanac-month">
-          <h3 class="almanac-month-label">
-            <time datetime="<%= month.strftime("%Y-%m") %>">
-              <%= l month.to_date, format: :month_year %>
-            </time>
-          </h3>
+          <div class="almanac-month-head">
+            <h3 class="almanac-month-label">
+              <time datetime="<%= month.strftime("%Y-%m") %>">
+                <%= month_label %>
+              </time>
+            </h3>
 
-          <ol class="almanac-timeline">
-            <% events.each do |event| %>
-              <%= render "event", event: event %>
+            <% if @moon_phases_by_month[month].present? %>
+              <%= render(
+                "moon_phase_strip",
+                moon_phases: @moon_phases_by_month[month],
+                month_label: month_label
+              ) %>
             <% end %>
-          </ol>
+          </div>
+
+          <% if @events_by_month[month].present? %>
+            <ol class="almanac-timeline">
+              <% @events_by_month[month].each do |event| %>
+                <%= render "event", event: event %>
+              <% end %>
+            </ol>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/almanac/show.html.erb
+++ b/app/views/almanac/show.html.erb
@@ -1,1 +1,49 @@
 <% content_for :title, "#{t("title")} • #{t(".title")}" %>
+
+<div class="rounded-lg border bg-card text-card-foreground shadow-sm
+  cosmic-card">
+  <div class="max-w-xl">
+    <h2 class="text-2xl font-bold text-cosmic"><%= t ".title" %></h2>
+    <p class="text-sm text-muted-foreground mt-1"><%= t ".subtitle" %></p>
+    <p class="text-xs text-muted-foreground mt-2 font-mono">
+      <%= t ".count", count: @events.size %>
+    </p>
+  </div>
+</div>
+
+<% if @events.any? %>
+  <section
+    aria-labelledby="almanac-timeline-heading"
+    class="rounded-lg border bg-card text-card-foreground shadow-sm cosmic-card"
+  >
+    <h2 id="almanac-timeline-heading" class="sr-only">
+      <%= t ".timeline.heading" %>
+    </h2>
+
+    <div class="almanac-board">
+      <% @events_by_month.each do |month, events| %>
+        <div class="almanac-month">
+          <h3 class="almanac-month-label">
+            <time datetime="<%= month.strftime("%Y-%m") %>">
+              <%= l month.to_date, format: :month_year %>
+            </time>
+          </h3>
+
+          <ol class="almanac-timeline">
+            <% events.each do |event| %>
+              <%= render "event", event: event %>
+            <% end %>
+          </ol>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% else %>
+  <div class="rounded-lg border bg-card text-card-foreground shadow-sm
+    cosmic-card text-center py-10">
+    <p class="text-lg font-bold"><%= t ".empty.title" %></p>
+    <p class="text-sm text-muted-foreground mt-1">
+      <%= t ".empty.description" %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/almanac/show.html.erb
+++ b/app/views/almanac/show.html.erb
@@ -6,7 +6,7 @@
     <h2 class="text-2xl font-bold text-cosmic"><%= t ".title" %></h2>
     <p class="text-sm text-muted-foreground mt-1"><%= t ".subtitle" %></p>
     <p class="text-xs text-muted-foreground mt-2 font-mono">
-      <%= t ".count", count: @events.size %>
+      <%= t ".count", count: @event_count %>
     </p>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-between items-center m-0 gap-4">
+<div class="flex flex-wrap justify-between items-center m-0 gap-4">
   <%= render "shared/navigation" %>
   <div class="flex items-center gap-4">
     <%= render "shared/location_selector" %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,4 +1,5 @@
-<nav aria-label="Main navigation" class="flex items-center gap-4">
+<nav aria-label="Main navigation" class="flex flex-wrap items-center
+  gap-x-4 gap-y-2">
   <%= link_to(
     sun_path,
     class: "flex items-center gap-2 text-gray-800 dark:text-gray-100

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -32,4 +32,15 @@
     ) %>
     <span class="text-sm font-medium"><%= t ".lunar_eclipses" %></span>
   <% end %>
+  <%= link_to(
+    almanac_path,
+    class: "flex items-center gap-2 text-gray-800 dark:text-gray-100
+      hover:text-cosmic dark:hover:text-cosmic transition-colors group"
+  ) do %>
+    <%= render(
+      "shared/icons/almanac",
+      class: "w-5 h-5 fill-current group-hover:scale-110 transition-transform"
+    ) %>
+    <span class="text-sm font-medium"><%= t ".almanac" %></span>
+  <% end %>
 </nav>

--- a/app/views/shared/icons/_almanac.html.erb
+++ b/app/views/shared/icons/_almanac.html.erb
@@ -1,0 +1,19 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 20 20"
+  class="<%= local_assigns[:class] %>"
+  aria-hidden="true"
+>
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H4a2
+      2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1zM4 8.5V16h12V8.5H4z"
+    fill="currentColor"
+  />
+  <path
+    d="M6.5 11.5a1 1 0 100 2 1 1 0 000-2zM10 11.5a1 1 0 100 2 1 1 0 000-2zM13.5
+      11.5a1 1 0 100 2 1 1 0 000-2z"
+    fill="currentColor"
+  />
+</svg>

--- a/config/initializers/astronoby.rb
+++ b/config/initializers/astronoby.rb
@@ -19,6 +19,10 @@ class SPK
     @inpop19a ||= Astronoby::Ephem.load("lib/astronoby/spk/inpop19a.bsp")
   end
 
+  def self.inpop19a
+    instance.inpop19a
+  end
+
   def self.for_time(time)
     instance.for_time(time)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,15 +14,27 @@ en:
       timeline:
         heading: Event timeline
       kinds:
+        december_solstice:
+          name: Solstice
+          title: December solstice
         greatest_elongation:
           name: Greatest elongation
           title: "%{body} at greatest elongation"
+        june_solstice:
+          name: Solstice
+          title: June solstice
         lunar_eclipse:
           name: Lunar eclipse
           title: "Lunar eclipse on %{date}"
+        march_equinox:
+          name: Equinox
+          title: March equinox
         opposition:
           name: Opposition
           title: "%{body} at opposition"
+        september_equinox:
+          name: Equinox
+          title: September equinox
   cardinal_direction:
     north: N
     north_east: NE

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,12 +12,12 @@ en:
       timeline:
         heading: Event timeline
       kinds:
+        greatest_elongation:
+          name: Greatest elongation
+          title: "%{body} at greatest elongation"
         opposition:
           name: Opposition
           title: "%{body} at opposition"
-        maximum_elongation:
-          name: Maximum elongation
-          title: "%{body} at maximum elongation"
   cardinal_direction:
     north: N
     north_east: NE

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,7 @@
 en:
   almanac:
+    moon_apsis_strip:
+      label: Moon distance in %{month}
     moon_phase_strip:
       label: Moon phases in %{month}
     show:
@@ -17,6 +19,12 @@ en:
         december_solstice:
           name: Solstice
           title: December solstice
+        earth_aphelion:
+          name: Aphelion
+          title: Earth at aphelion
+        earth_perihelion:
+          name: Perihelion
+          title: Earth at perihelion
         greatest_elongation:
           name: Greatest elongation
           title: "%{body} at greatest elongation"
@@ -29,6 +37,12 @@ en:
         march_equinox:
           name: Equinox
           title: March equinox
+        moon_apogee:
+          name: Apogee
+          title: The Moon at apogee
+        moon_perigee:
+          name: Perigee
+          title: The Moon at perigee
         moon_planet_conjunction:
           name: Conjunction
           title: "The Moon meets %{body}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,9 @@ en:
         greatest_elongation:
           name: Greatest elongation
           title: "%{body} at greatest elongation"
+        lunar_eclipse:
+          name: Lunar eclipse
+          title: "Lunar eclipse on %{date}"
         opposition:
           name: Opposition
           title: "%{body} at opposition"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,9 +29,15 @@ en:
         march_equinox:
           name: Equinox
           title: March equinox
+        moon_planet_conjunction:
+          name: Conjunction
+          title: "The Moon meets %{body}"
         opposition:
           name: Opposition
           title: "%{body} at opposition"
+        planetary_conjunction:
+          name: Conjunction
+          title: "%{body} meets %{secondary_body}"
         september_equinox:
           name: Equinox
           title: September equinox

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,7 @@
 en:
   almanac:
+    moon_phase_strip:
+      label: Moon phases in %{month}
     show:
       title: Almanac
       subtitle: Celestial events coming up over the next twelve months.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,22 @@ en:
   almanac:
     show:
       title: Almanac
+      subtitle: Celestial events coming up over the next twelve months.
+      count:
+        one: 1 event
+        other: "%{count} events"
+      empty:
+        title: No events on the horizon
+        description: There is nothing scheduled for the next twelve months.
+      timeline:
+        heading: Event timeline
+      kinds:
+        opposition:
+          name: Opposition
+          title: "%{body} at opposition"
+        maximum_elongation:
+          name: Maximum elongation
+          title: "%{body} at maximum elongation"
   cardinal_direction:
     north: N
     north_east: NE
@@ -203,6 +219,7 @@ en:
     formats:
       abbreviated_day: "%a"
       full_month_short: "%B %d"
+      month_year: "%B %Y"
   description: Open source astronomy dashboard.
   location:
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  almanac:
+    show:
+      title: Almanac
   cardinal_direction:
     north: N
     north_east: NE
@@ -759,6 +762,7 @@ en:
         label: Accept cookies for location features
         title: Accept cookies for location features
     navigation:
+      almanac: Almanac
       lunar_eclipses: Lunar Eclipses
       moon: Moon
       sun: Sun

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resource :location, only: [:edit, :update], controller: :location
   resource :time, only: [:edit, :update, :destroy], controller: :time
 
+  resource :almanac, only: [:show], controller: :almanac
   resources :lunar_eclipses, only: [:index, :show]
   resource :moon, only: [:show], controller: :moon
   resource :sun, only: [:show], controller: :sun

--- a/db/migrate/20260830202436_create_celestial_events.rb
+++ b/db/migrate/20260830202436_create_celestial_events.rb
@@ -1,0 +1,13 @@
+class CreateCelestialEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :celestial_events do |t|
+      t.string :kind
+      t.decimal :peak_tt, null: false, precision: 15, scale: 6
+      t.datetime :peak_at, null: false
+      t.string :primary_body
+      t.string :secondary_body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901090000_add_indexes_to_celestial_events.rb
+++ b/db/migrate/20260901090000_add_indexes_to_celestial_events.rb
@@ -1,0 +1,6 @@
+class AddIndexesToCelestialEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_index :celestial_events, :peak_at
+    add_index :celestial_events, [:kind, :peak_at]
+  end
+end

--- a/db/migrate/20260901120000_require_kind_on_celestial_events.rb
+++ b/db/migrate/20260901120000_require_kind_on_celestial_events.rb
@@ -1,0 +1,5 @@
+class RequireKindOnCelestialEvents < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :celestial_events, :kind, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_30_202436) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_090000) do
   create_table "celestial_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "kind"
@@ -19,5 +19,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_30_202436) do
     t.string "primary_body"
     t.string "secondary_body"
     t.datetime "updated_at", null: false
+    t.index ["kind", "peak_at"], name: "index_celestial_events_on_kind_and_peak_at"
+    t.index ["peak_at"], name: "index_celestial_events_on_peak_at"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_30_202436) do
+  create_table "celestial_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "kind"
+    t.datetime "peak_at", null: false
+    t.decimal "peak_tt", precision: 15, scale: 6, null: false
+    t.string "primary_body"
+    t.string "secondary_body"
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_01_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_120000) do
   create_table "celestial_events", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "kind"
+    t.string "kind", null: false
     t.datetime "peak_at", null: false
     t.decimal "peak_tt", precision: 15, scale: 6, null: false
     t.string "primary_body"

--- a/spec/factories/celestial_events.rb
+++ b/spec/factories/celestial_events.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       peak { Time.utc(2023, 2, 24, 12) }
     end
 
-    kind { "eclipse" }
+    kind { "opposition" }
     peak_tt { Astronoby::Instant.from_time(peak).tt }
   end
 end

--- a/spec/factories/celestial_events.rb
+++ b/spec/factories/celestial_events.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :celestial_event do
     transient do
-      peak { Time.utc(2023, 2, 24, 12) }
+      peak { Time.utc(2026, 8, 28, 4, 12) }
     end
 
-    kind { "opposition" }
+    kind { CelestialEvent::LUNAR_ECLIPSE }
     peak_tt { Astronoby::Instant.from_time(peak).tt }
   end
 end

--- a/spec/factories/celestial_events.rb
+++ b/spec/factories/celestial_events.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :celestial_event do
+    transient do
+      peak { Time.utc(2023, 2, 24, 12) }
+    end
+
+    kind { "eclipse" }
+    peak_tt { Astronoby::Instant.from_time(peak).tt }
+  end
+end

--- a/spec/helpers/celestial_event_helper_spec.rb
+++ b/spec/helpers/celestial_event_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CelestialEventHelper do
 
   describe "#celestial_event_title" do
     it "names the body and its opposition" do
-      event = build(
+      event = create(
         :celestial_event,
         kind: CelestialEvent::OPPOSITION,
         primary_body: "Mars"
@@ -17,7 +17,7 @@ RSpec.describe CelestialEventHelper do
     end
 
     it "names the body and its greatest elongation" do
-      event = build(
+      event = create(
         :celestial_event,
         kind: CelestialEvent::GREATEST_ELONGATION,
         primary_body: "Mercury"
@@ -25,6 +25,18 @@ RSpec.describe CelestialEventHelper do
 
       expect(celestial_event_title(event))
         .to eq("Mercury at greatest elongation")
+    end
+
+    it "names an event that has no body without one" do
+      event = create(
+        :celestial_event,
+        kind: CelestialEvent::LUNAR_ECLIPSE,
+        primary_body: nil,
+        peak: Time.utc(2026, 8, 28, 12)
+      )
+
+      expect(celestial_event_title(event))
+        .to eq("Lunar eclipse on August 28, 2026")
     end
   end
 
@@ -41,6 +53,12 @@ RSpec.describe CelestialEventHelper do
       event = build(:celestial_event, primary_body: "Jupiter")
 
       expect(celestial_event_body_name(event)).to eq("Jupiter")
+    end
+
+    it "returns nothing when the event has no body" do
+      event = build(:celestial_event, primary_body: nil)
+
+      expect(celestial_event_body_name(event)).to be_nil
     end
   end
 end

--- a/spec/helpers/celestial_event_helper_spec.rb
+++ b/spec/helpers/celestial_event_helper_spec.rb
@@ -38,6 +38,27 @@ RSpec.describe CelestialEventHelper do
       expect(celestial_event_title(event))
         .to eq("Lunar eclipse on August 28, 2026")
     end
+
+    it "names both bodies of a two-body event" do
+      event = create(
+        :celestial_event,
+        kind: CelestialEvent::PLANETARY_CONJUNCTION,
+        primary_body: "Mars",
+        secondary_body: "Jupiter"
+      )
+
+      expect(celestial_event_title(event)).to eq("Mars meets Jupiter")
+    end
+
+    it "names the planet the Moon meets" do
+      event = create(
+        :celestial_event,
+        kind: CelestialEvent::MOON_PLANET_CONJUNCTION,
+        primary_body: "Venus"
+      )
+
+      expect(celestial_event_title(event)).to eq("The Moon meets Venus")
+    end
   end
 
   describe "#celestial_event_kind_name" do

--- a/spec/helpers/celestial_event_helper_spec.rb
+++ b/spec/helpers/celestial_event_helper_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CelestialEventHelper do
+  include CelestialEventHelper
+
+  describe "#celestial_event_title" do
+    it "names the body and its opposition" do
+      event = build(
+        :celestial_event,
+        kind: CelestialEvent::OPPOSITION,
+        primary_body: "Mars"
+      )
+
+      expect(celestial_event_title(event)).to eq("Mars at opposition")
+    end
+
+    it "names the body and its maximum elongation" do
+      event = build(
+        :celestial_event,
+        kind: CelestialEvent::MAXIMUM_ELONGATION,
+        primary_body: "Mercury"
+      )
+
+      expect(celestial_event_title(event))
+        .to eq("Mercury at maximum elongation")
+    end
+  end
+
+  describe "#celestial_event_kind_name" do
+    it "returns the human name of the kind" do
+      event = build(:celestial_event, kind: CelestialEvent::OPPOSITION)
+
+      expect(celestial_event_kind_name(event)).to eq("Opposition")
+    end
+  end
+
+  describe "#celestial_event_body_name" do
+    it "translates the stored body name" do
+      event = build(:celestial_event, primary_body: "Jupiter")
+
+      expect(celestial_event_body_name(event)).to eq("Jupiter")
+    end
+  end
+end

--- a/spec/helpers/celestial_event_helper_spec.rb
+++ b/spec/helpers/celestial_event_helper_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe CelestialEventHelper do
       expect(celestial_event_title(event)).to eq("Mars at opposition")
     end
 
-    it "names the body and its maximum elongation" do
+    it "names the body and its greatest elongation" do
       event = build(
         :celestial_event,
-        kind: CelestialEvent::MAXIMUM_ELONGATION,
+        kind: CelestialEvent::GREATEST_ELONGATION,
         primary_body: "Mercury"
       )
 
       expect(celestial_event_title(event))
-        .to eq("Mercury at maximum elongation")
+        .to eq("Mercury at greatest elongation")
     end
   end
 

--- a/spec/helpers/celestial_event_helper_spec.rb
+++ b/spec/helpers/celestial_event_helper_spec.rb
@@ -62,6 +62,26 @@ RSpec.describe CelestialEventHelper do
   end
 
   describe "#celestial_event_kind_name" do
+    it "has a name and a title for every kind shown in the timeline" do
+      kinds = CelestialEvent::KINDS - CelestialEvent::MOON_PHASE_KINDS
+
+      kinds.each do |kind|
+        expect(I18n.exists?("almanac.show.kinds.#{kind}.name"))
+          .to be(true), "missing name for #{kind}"
+        expect(I18n.exists?("almanac.show.kinds.#{kind}.title"))
+          .to be(true), "missing title for #{kind}"
+      end
+    end
+
+    it "has a name and a glyph for every moon phase shown in the strip" do
+      CelestialEvent::MOON_PHASE_KINDS.each do |kind|
+        expect(I18n.exists?("moon.phases.#{kind}"))
+          .to be(true), "missing name for #{kind}"
+        expect(I18n.exists?("moon.phase_emojis.#{kind}"))
+          .to be(true), "missing glyph for #{kind}"
+      end
+    end
+
     it "returns the human name of the kind" do
       event = build(:celestial_event, kind: CelestialEvent::OPPOSITION)
 

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvent, type: :model do
+  describe "factory" do
+    it "is valid" do
+      expect(build(:celestial_event)).to be_valid
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:kind) }
+    it { is_expected.to validate_presence_of(:peak_tt) }
+    it { is_expected.to validate_presence_of(:peak_at) }
+  end
+
+  describe "#peak_at" do
+    it "is set from peak_tt" do
+      event = build(:celestial_event, peak_tt: 2437870.0003965567)
+      expect(event.peak_at).to be_nil
+
+      event.valid?
+
+      expect(event.peak_at.round).to eq(Time.utc(1962, 7, 24, 12))
+    end
+  end
+
+  describe "#instant" do
+    it "returns an Astronoby::Instant" do
+      event = build(:celestial_event, peak_tt: 2437870.0003965567)
+
+      expect(event.instant).to be_a(Astronoby::Instant)
+      expect(event.instant.tt).to eq(0.2437870000397e7)
+    end
+  end
+
+  describe "scopes" do
+    describe ".between" do
+      it "returns events between two dates" do
+        event1 = create(:celestial_event, peak: Time.utc(2024, 1, 1))
+        event2 = create(:celestial_event, peak: Time.utc(2024, 6, 1))
+        _event3 = create(:celestial_event, peak: Time.utc(2024, 12, 31))
+
+        between = CelestialEvent.between(
+          Time.utc(2024, 1, 1),
+          Time.utc(2024, 6, 30)
+        )
+
+        expect(between).to contain_exactly(event1, event2)
+      end
+    end
+
+    describe ".of_kind" do
+      it "returns events of the given kind" do
+        event1 = create(:celestial_event, kind: "eclipse")
+        _event2 = create(:celestial_event, kind: "transit")
+        event3 = create(:celestial_event, kind: "eclipse")
+
+        eclipses = CelestialEvent.of_kind("eclipse")
+
+        expect(eclipses).to contain_exactly(event1, event3)
+      end
+    end
+
+    describe ".chronological" do
+      it "returns events in chronological order" do
+        event1 = create(:celestial_event, peak: Time.utc(2024, 6, 1))
+        event2 = create(:celestial_event, peak: Time.utc(2024, 1, 1))
+        event3 = create(:celestial_event, peak: Time.utc(2024, 12, 31))
+
+        chronological = CelestialEvent.chronological
+
+        expect(chronological).to eq([event2, event1, event3])
+      end
+    end
+  end
+end

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CelestialEvent, type: :model do
     describe ".of_kind" do
       it "returns events of the given kind" do
         event1 = create(:celestial_event, kind: "opposition")
-        _event2 = create(:celestial_event, kind: "maximum_elongation")
+        _event2 = create(:celestial_event, kind: "greatest_elongation")
         event3 = create(:celestial_event, kind: "opposition")
 
         oppositions = CelestialEvent.of_kind("opposition")

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -103,20 +103,40 @@ RSpec.describe CelestialEvent, type: :model do
     describe ".moon_phases" do
       it "returns only the principal moon phases" do
         full_moon = create(:celestial_event, kind: CelestialEvent::FULL_MOON)
-        _opposition = create(:celestial_event,
-          kind: CelestialEvent::OPPOSITION, primary_body: "Mars")
+        _opposition = create(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: "Mars"
+        )
 
         expect(CelestialEvent.moon_phases).to contain_exactly(full_moon)
       end
     end
 
+    describe ".moon_apsides" do
+      it "returns only the lunar apsides" do
+        perigee = create(:celestial_event, kind: CelestialEvent::MOON_PERIGEE)
+        _opposition = create(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: "Mars"
+        )
+
+        expect(CelestialEvent.moon_apsides).to contain_exactly(perigee)
+      end
+    end
+
     describe ".notable" do
-      it "returns everything that is not a principal moon phase" do
+      it "returns everything that is not part of the lunar rhythm" do
         _full_moon = create(:celestial_event, kind: CelestialEvent::FULL_MOON)
-        opposition = create(:celestial_event,
-          kind: CelestialEvent::OPPOSITION, primary_body: "Mars")
-        eclipse = create(:celestial_event,
-          kind: CelestialEvent::LUNAR_ECLIPSE)
+        _perigee = create(:celestial_event, kind: CelestialEvent::MOON_PERIGEE)
+        _apogee = create(:celestial_event, kind: CelestialEvent::MOON_APOGEE)
+        opposition = create(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: "Mars"
+        )
+        eclipse = create(:celestial_event, kind: CelestialEvent::LUNAR_ECLIPSE)
 
         expect(CelestialEvent.notable)
           .to contain_exactly(opposition, eclipse)

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -100,6 +100,29 @@ RSpec.describe CelestialEvent, type: :model do
       end
     end
 
+    describe ".moon_phases" do
+      it "returns only the principal moon phases" do
+        full_moon = create(:celestial_event, kind: CelestialEvent::FULL_MOON)
+        _opposition = create(:celestial_event,
+          kind: CelestialEvent::OPPOSITION, primary_body: "Mars")
+
+        expect(CelestialEvent.moon_phases).to contain_exactly(full_moon)
+      end
+    end
+
+    describe ".notable" do
+      it "returns everything that is not a principal moon phase" do
+        _full_moon = create(:celestial_event, kind: CelestialEvent::FULL_MOON)
+        opposition = create(:celestial_event,
+          kind: CelestialEvent::OPPOSITION, primary_body: "Mars")
+        eclipse = create(:celestial_event,
+          kind: CelestialEvent::LUNAR_ECLIPSE)
+
+        expect(CelestialEvent.notable)
+          .to contain_exactly(opposition, eclipse)
+      end
+    end
+
     describe ".chronological" do
       it "returns events in chronological order" do
         event1 = create(:celestial_event, peak: Time.utc(2024, 6, 1))

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe CelestialEvent, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:kind) }
+    it {
+      is_expected.to validate_inclusion_of(:kind)
+        .in_array(CelestialEvent::KINDS)
+    }
     it { is_expected.to validate_presence_of(:peak_tt) }
     it { is_expected.to validate_presence_of(:peak_at) }
   end
@@ -51,13 +55,13 @@ RSpec.describe CelestialEvent, type: :model do
 
     describe ".of_kind" do
       it "returns events of the given kind" do
-        event1 = create(:celestial_event, kind: "eclipse")
-        _event2 = create(:celestial_event, kind: "transit")
-        event3 = create(:celestial_event, kind: "eclipse")
+        event1 = create(:celestial_event, kind: "opposition")
+        _event2 = create(:celestial_event, kind: "greatest_elongation")
+        event3 = create(:celestial_event, kind: "opposition")
 
-        eclipses = CelestialEvent.of_kind("eclipse")
+        oppositions = CelestialEvent.of_kind("opposition")
 
-        expect(eclipses).to contain_exactly(event1, event3)
+        expect(oppositions).to contain_exactly(event1, event3)
       end
     end
 

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -9,12 +9,35 @@ RSpec.describe CelestialEvent, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:kind) }
-    it {
+    it do
       is_expected.to validate_inclusion_of(:kind)
         .in_array(CelestialEvent::KINDS)
-    }
+    end
     it { is_expected.to validate_presence_of(:peak_tt) }
     it { is_expected.to validate_presence_of(:peak_at) }
+
+    describe "#primary_body" do
+      it "is required for a kind that names a body" do
+        event = build(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: nil
+        )
+
+        expect(event).not_to be_valid
+        expect(event.errors[:primary_body]).to include("can't be blank")
+      end
+
+      it "is optional for a kind that names no body" do
+        event = build(
+          :celestial_event,
+          kind: CelestialEvent::LUNAR_ECLIPSE,
+          primary_body: nil
+        )
+
+        expect(event).to be_valid
+      end
+    end
   end
 
   describe "#peak_at" do
@@ -55,9 +78,21 @@ RSpec.describe CelestialEvent, type: :model do
 
     describe ".of_kind" do
       it "returns events of the given kind" do
-        event1 = create(:celestial_event, kind: "opposition")
-        _event2 = create(:celestial_event, kind: "greatest_elongation")
-        event3 = create(:celestial_event, kind: "opposition")
+        event1 = create(
+          :celestial_event,
+          kind: "opposition",
+          primary_body: "Mars"
+        )
+        _event2 = create(
+          :celestial_event,
+          kind: "greatest_elongation",
+          primary_body: "Venus"
+        )
+        event3 = create(
+          :celestial_event,
+          kind: "opposition",
+          primary_body: "Jupiter"
+        )
 
         oppositions = CelestialEvent.of_kind("opposition")
 

--- a/spec/models/celestial_event_spec.rb
+++ b/spec/models/celestial_event_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CelestialEvent, type: :model do
     describe ".of_kind" do
       it "returns events of the given kind" do
         event1 = create(:celestial_event, kind: "opposition")
-        _event2 = create(:celestial_event, kind: "greatest_elongation")
+        _event2 = create(:celestial_event, kind: "maximum_elongation")
         event3 = create(:celestial_event, kind: "opposition")
 
         oppositions = CelestialEvent.of_kind("opposition")

--- a/spec/models/celestial_events/earth_aphelia_perihelia_generator_spec.rb
+++ b/spec/models/celestial_events/earth_aphelia_perihelia_generator_spec.rb
@@ -3,19 +3,31 @@ require "rails_helper"
 RSpec.describe CelestialEvents::EarthApheliaPeriheliaGenerator, type: :model do
   describe "#generate" do
     it "creates celestial events for aphelion and perihelion" do
-      start_date = Time.utc(2026, 1, 1)
-      end_date = Time.utc(2028, 1, 1)
+      start_date = Time.utc(2025, 12, 1)
+      end_date = Time.utc(2027, 12, 1)
 
       generator = CelestialEvents::EarthApheliaPeriheliaGenerator
         .new(start_date, end_date)
 
       expect { generator.generate }
         .to change(CelestialEvent, :count)
-        .by(3)
-      expect(CelestialEvent.where(kind: CelestialEvent::EARTH_APHELION).count)
+        .by(4)
+      expect(CelestialEvent.of_kind(CelestialEvent::EARTH_APHELION).count)
         .to be 2
-      expect(CelestialEvent.where(kind: CelestialEvent::EARTH_PERIHELION).count)
-        .to be 1
+      expect(CelestialEvent.of_kind(CelestialEvent::EARTH_PERIHELION).count)
+        .to be 2
+    end
+
+    it "misses an apsis within a few days of the start of the period" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      CelestialEvents::EarthApheliaPeriheliaGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.of_kind(CelestialEvent::EARTH_PERIHELION))
+        .not_to exist
     end
   end
 end

--- a/spec/models/celestial_events/earth_aphelia_perihelia_generator_spec.rb
+++ b/spec/models/celestial_events/earth_aphelia_perihelia_generator_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::EarthApheliaPeriheliaGenerator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for aphelion and perihelion" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2028, 1, 1)
+
+      generator = CelestialEvents::EarthApheliaPeriheliaGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change(CelestialEvent, :count)
+        .by(3)
+      expect(CelestialEvent.where(kind: CelestialEvent::EARTH_APHELION).count)
+        .to be 2
+      expect(CelestialEvent.where(kind: CelestialEvent::EARTH_PERIHELION).count)
+        .to be 1
+    end
+  end
+end

--- a/spec/models/celestial_events/equinoxes_solstices_generator_spec.rb
+++ b/spec/models/celestial_events/equinoxes_solstices_generator_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::EquinoxesSolsticesGenerator, type: :model do
+  describe "#generate" do
+    it "creates the four season events of each year" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 12, 31)
+      generator = CelestialEvents::EquinoxesSolsticesGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change { CelestialEvent.count }.from(0).to(8)
+    end
+
+    it "creates each season kind of celestial event" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      CelestialEvents::EquinoxesSolsticesGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.chronological.pluck(:kind))
+        .to eq(CelestialEvent::SEASON_KINDS)
+    end
+
+    it "keeps the events within the requested period" do
+      start_date = Time.utc(2026, 5, 1)
+      end_date = Time.utc(2026, 10, 1)
+
+      CelestialEvents::EquinoxesSolsticesGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.pluck(:peak_at))
+        .to all(be_between(start_date, end_date))
+    end
+
+    it "covers a period spanning the turn of a year" do
+      start_date = Time.utc(2026, 11, 1)
+      end_date = Time.utc(2027, 4, 1)
+
+      CelestialEvents::EquinoxesSolsticesGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.chronological.pluck(:kind)).to eq(
+        [CelestialEvent::DECEMBER_SOLSTICE, CelestialEvent::MARCH_EQUINOX]
+      )
+    end
+  end
+end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to receive(:new).and_call_original
       allow(CelestialEvents::PlanetaryConjunctionsGenerator)
         .to receive(:new).and_call_original
+      allow(CelestialEvents::EarthApheliaPeriheliaGenerator)
+        .to receive(:new).and_call_original
+      allow(CelestialEvents::MoonApogeesPerigeesGenerator)
+        .to receive(:new).and_call_original
 
       CelestialEvents::Generator
         .new(start_date, end_date)
@@ -70,6 +74,12 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to have_received(:new)
         .with(start_date, end_date)
       expect(CelestialEvents::PlanetaryConjunctionsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::MoonApogeesPerigeesGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::EarthApheliaPeriheliaGenerator)
         .to have_received(:new)
         .with(start_date, end_date)
     end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to receive(:new).and_call_original
       allow(CelestialEvents::EquinoxesSolsticesGenerator)
         .to receive(:new).and_call_original
+      allow(CelestialEvents::MoonPlanetConjunctionsGenerator)
+        .to receive(:new).and_call_original
+      allow(CelestialEvents::PlanetaryConjunctionsGenerator)
+        .to receive(:new).and_call_original
 
       CelestialEvents::Generator
         .new(start_date, end_date)
@@ -60,6 +64,12 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to have_received(:new)
         .with(start_date, end_date)
       expect(CelestialEvents::EquinoxesSolsticesGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::MoonPlanetConjunctionsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::PlanetaryConjunctionsGenerator)
         .to have_received(:new)
         .with(start_date, end_date)
     end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::Generator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for the given event type" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+      allow(CelestialEvents::OppositionsGenerator)
+        .to receive(:new).and_call_original
+
+      CelestialEvents::Generator.new(
+        CelestialEvents::Generator::OPPOSITIONS,
+        start_date,
+        end_date
+      ).generate
+
+      expect(CelestialEvents::OppositionsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+    end
+
+    it "raises an error for unsupported event types" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::Generator.new(
+        :unsupported_event_type,
+        start_date,
+        end_date
+      )
+
+      expect { generator.generate }
+        .to raise_error(ArgumentError, /Unsupported event type/)
+    end
+  end
+end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -34,12 +34,22 @@ RSpec.describe CelestialEvents::Generator, type: :model do
       end_date = Time.utc(2027, 1, 1)
       allow(CelestialEvents::OppositionsGenerator)
         .to receive(:new).and_call_original
+      allow(CelestialEvents::LunarEclipsesGenerator)
+        .to receive(:new).and_call_original
+      allow(CelestialEvents::GreatestElongationsGenerator)
+        .to receive(:new).and_call_original
 
       CelestialEvents::Generator
         .new(start_date, end_date)
         .generate_all
 
       expect(CelestialEvents::OppositionsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::LunarEclipsesGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::GreatestElongationsGenerator)
         .to have_received(:new)
         .with(start_date, end_date)
     end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -8,11 +8,9 @@ RSpec.describe CelestialEvents::Generator, type: :model do
       allow(CelestialEvents::OppositionsGenerator)
         .to receive(:new).and_call_original
 
-      CelestialEvents::Generator.new(
-        CelestialEvents::Generator::OPPOSITIONS,
-        start_date,
-        end_date
-      ).generate
+      CelestialEvents::Generator
+        .new(start_date, end_date)
+        .generate(CelestialEvents::Generator::OPPOSITIONS)
 
       expect(CelestialEvents::OppositionsGenerator)
         .to have_received(:new)
@@ -23,14 +21,27 @@ RSpec.describe CelestialEvents::Generator, type: :model do
       start_date = Time.utc(2026, 1, 1)
       end_date = Time.utc(2027, 1, 1)
 
-      generator = CelestialEvents::Generator.new(
-        :unsupported_event_type,
-        start_date,
-        end_date
-      )
+      generator = CelestialEvents::Generator.new(start_date, end_date)
 
-      expect { generator.generate }
+      expect { generator.generate(:unsupported_event_type) }
         .to raise_error(ArgumentError, /Unsupported event type/)
+    end
+  end
+
+  describe "#generate_all" do
+    it "creates celestial events for all supported event types" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+      allow(CelestialEvents::OppositionsGenerator)
+        .to receive(:new).and_call_original
+
+      CelestialEvents::Generator
+        .new(start_date, end_date)
+        .generate_all
+
+      expect(CelestialEvents::OppositionsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
     end
   end
 end

--- a/spec/models/celestial_events/generator_spec.rb
+++ b/spec/models/celestial_events/generator_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to receive(:new).and_call_original
       allow(CelestialEvents::GreatestElongationsGenerator)
         .to receive(:new).and_call_original
+      allow(CelestialEvents::MoonPhasesGenerator)
+        .to receive(:new).and_call_original
+      allow(CelestialEvents::EquinoxesSolsticesGenerator)
+        .to receive(:new).and_call_original
 
       CelestialEvents::Generator
         .new(start_date, end_date)
@@ -50,6 +54,12 @@ RSpec.describe CelestialEvents::Generator, type: :model do
         .to have_received(:new)
         .with(start_date, end_date)
       expect(CelestialEvents::GreatestElongationsGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::MoonPhasesGenerator)
+        .to have_received(:new)
+        .with(start_date, end_date)
+      expect(CelestialEvents::EquinoxesSolsticesGenerator)
         .to have_received(:new)
         .with(start_date, end_date)
     end

--- a/spec/models/celestial_events/greatest_elongations_generator_spec.rb
+++ b/spec/models/celestial_events/greatest_elongations_generator_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::GreatestElongationsGenerator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for greatest elongations of planets" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::GreatestElongationsGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change { CelestialEvent.count }.from(0).to(7)
+    end
+
+    it "creates greatest elongation kind of celestial events" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::GreatestElongationsGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.distinct(:kind).pluck(:kind))
+        .to contain_exactly(CelestialEvent::GREATEST_ELONGATION)
+    end
+
+    it "sets the peak_tt of the celestial events to relevant values" do
+      start_date = Time.utc(2026, 1, 1)
+      start_tt = Astronoby::Instant.from_time(start_date).tt
+      end_date = Time.utc(2027, 1, 1)
+      end_tt = Astronoby::Instant.from_time(end_date).tt
+
+      generator = CelestialEvents::GreatestElongationsGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.pluck(:peak_tt))
+        .to all(be >= start_tt)
+        .and all(be <= end_tt)
+    end
+  end
+end

--- a/spec/models/celestial_events/lunar_eclipses_generator_spec.rb
+++ b/spec/models/celestial_events/lunar_eclipses_generator_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::LunarEclipsesGenerator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for lunar eclipses" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::LunarEclipsesGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change { CelestialEvent.count }.from(0).to(2)
+    end
+
+    it "creates lunar eclipse kind of celestial events" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::LunarEclipsesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.distinct(:kind).pluck(:kind))
+        .to contain_exactly(CelestialEvent::LUNAR_ECLIPSE)
+    end
+
+    it "sets the peak_tt of the celestial events to relevant values" do
+      start_date = Time.utc(2026, 1, 1)
+      start_tt = Astronoby::Instant.from_time(start_date).tt
+      end_date = Time.utc(2027, 1, 1)
+      end_tt = Astronoby::Instant.from_time(end_date).tt
+
+      generator = CelestialEvents::LunarEclipsesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.pluck(:peak_tt))
+        .to all(be >= start_tt)
+        .and all(be <= end_tt)
+    end
+  end
+end

--- a/spec/models/celestial_events/moon_apogees_perigees_generator_spec.rb
+++ b/spec/models/celestial_events/moon_apogees_perigees_generator_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::MoonApogeesPerigeesGenerator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for apogee and perigee" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::MoonApogeesPerigeesGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change(CelestialEvent, :count)
+        .by(27)
+      expect(CelestialEvent.where(kind: CelestialEvent::MOON_APOGEE).count)
+        .to be 13
+      expect(CelestialEvent.where(kind: CelestialEvent::MOON_PERIGEE).count)
+        .to be 14
+    end
+  end
+end

--- a/spec/models/celestial_events/moon_phases_generator_spec.rb
+++ b/spec/models/celestial_events/moon_phases_generator_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::MoonPhasesGenerator, type: :model do
+  describe "#generate" do
+    it "creates a celestial event for each principal phase of the period" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2026, 4, 1)
+
+      generator = CelestialEvents::MoonPhasesGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change { CelestialEvent.count }.from(0).to(16)
+    end
+
+    it "creates the four principal moon phase kinds" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::MoonPhasesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.distinct(:kind).pluck(:kind))
+        .to contain_exactly(*CelestialEvent::MOON_PHASE_KINDS)
+    end
+
+    it "covers in full every month the period touches" do
+      start_date = Time.utc(2026, 6, 10)
+      end_date = Time.utc(2026, 8, 20)
+
+      generator = CelestialEvents::MoonPhasesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.pluck(:peak_at))
+        .to all(be_between(Time.utc(2026, 6, 1), Time.utc(2026, 9, 1)))
+    end
+
+    it "includes the phases of a partial month that precede the period" do
+      start_date = Time.utc(2026, 6, 10)
+      end_date = Time.utc(2026, 8, 20)
+
+      generator = CelestialEvents::MoonPhasesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.where(peak_at: ...start_date)).to exist
+    end
+
+    it "does not create the same phase twice" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::MoonPhasesGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      peak_ats = CelestialEvent.pluck(:peak_at)
+
+      expect(peak_ats).to eq(peak_ats.uniq)
+    end
+  end
+end

--- a/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
+++ b/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::MoonPlanetConjunctionsGenerator, type: :model do
+  describe "#generate" do
+    it "creates an event for each naked-eye planet the Moon passes" do
+      start_date = Time.utc(2026, 9, 1)
+      end_date = Time.utc(2026, 10, 1)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.distinct.pluck(:primary_body))
+        .to match_array(
+          CelestialEvents::MoonPlanetConjunctionsGenerator::PLANETS
+        )
+    end
+
+    it "names the planet rather than the Moon, which the kind implies" do
+      start_date = Time.utc(2026, 10, 1)
+      end_date = Time.utc(2026, 10, 20)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      event = CelestialEvent.chronological.first
+
+      expect(event.kind).to eq(CelestialEvent::MOON_PLANET_CONJUNCTION)
+      expect(event.primary_body).to eq("Mars")
+      expect(event.secondary_body).to be_nil
+    end
+
+    it "skips a pairing that is lost in the Sun" do
+      start_date = Time.utc(2026, 1, 14)
+      end_date = Time.utc(2026, 1, 22)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.count).to eq(0)
+    end
+  end
+end

--- a/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
+++ b/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
@@ -56,5 +56,28 @@ RSpec.describe CelestialEvents::MoonPlanetConjunctionsGenerator, type: :model do
 
       expect(CelestialEvent.count).to eq(0)
     end
+    it "finds an approach that sits close to the start of the period" do
+      # The Moon meets Jupiter on 2026-10-06 at 10:23, an hour in.
+      start_date = Time.utc(2026, 10, 6, 9, 0)
+      end_date = Time.utc(2026, 10, 9, 9, 0)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.pluck(:primary_body)).to eq(["Jupiter"])
+    end
+
+    it "creates nothing outside the period it was asked for" do
+      start_date = Time.utc(2026, 9, 20, 6, 0)
+      end_date = Time.utc(2026, 10, 6, 7, 0)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.pluck(:peak_at))
+        .to all(be_between(start_date, end_date))
+    end
   end
 end

--- a/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
+++ b/spec/models/celestial_events/moon_planet_conjunctions_generator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CelestialEvents::MoonPlanetConjunctionsGenerator, type: :model do
   describe "#generate" do
     it "creates an event for each naked-eye planet the Moon passes" do
       start_date = Time.utc(2026, 9, 1)
-      end_date = Time.utc(2026, 10, 1)
+      end_date = Time.utc(2027, 6, 1)
 
       CelestialEvents::MoonPlanetConjunctionsGenerator
         .new(start_date, end_date)
@@ -16,6 +16,18 @@ RSpec.describe CelestialEvents::MoonPlanetConjunctionsGenerator, type: :model do
         )
     end
 
+    it "skips a pairing whose planet is too faint to be a sight" do
+      start_date = Time.utc(2026, 9, 1)
+      end_date = Time.utc(2026, 11, 1)
+
+      CelestialEvents::MoonPlanetConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.where(primary_body: "Mars")).not_to exist
+      expect(CelestialEvent.where(primary_body: "Jupiter")).to exist
+    end
+
     it "names the planet rather than the Moon, which the kind implies" do
       start_date = Time.utc(2026, 10, 1)
       end_date = Time.utc(2026, 10, 20)
@@ -24,11 +36,14 @@ RSpec.describe CelestialEvents::MoonPlanetConjunctionsGenerator, type: :model do
         .new(start_date, end_date)
         .generate
 
-      event = CelestialEvent.chronological.first
+      events = CelestialEvent.all
 
-      expect(event.kind).to eq(CelestialEvent::MOON_PLANET_CONJUNCTION)
-      expect(event.primary_body).to eq("Mars")
-      expect(event.secondary_body).to be_nil
+      expect(events.pluck(:kind).uniq)
+        .to eq([CelestialEvent::MOON_PLANET_CONJUNCTION])
+      expect(events.pluck(:primary_body)).to all(
+        be_in(CelestialEvents::MoonPlanetConjunctionsGenerator::PLANETS)
+      )
+      expect(events.pluck(:secondary_body).uniq).to eq([nil])
     end
 
     it "skips a pairing that is lost in the Sun" do

--- a/spec/models/celestial_events/oppositions_generator_spec.rb
+++ b/spec/models/celestial_events/oppositions_generator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CelestialEvents::OppositionsGenerator, type: :model do
 
       generator.generate
 
-      expect(CelestialEvent.pluck(:kind).uniq)
+      expect(CelestialEvent.distinct(:kind).pluck(:kind))
         .to contain_exactly(CelestialEvent::OPPOSITION)
     end
 

--- a/spec/models/celestial_events/oppositions_generator_spec.rb
+++ b/spec/models/celestial_events/oppositions_generator_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::OppositionsGenerator, type: :model do
+  describe "#generate" do
+    it "creates celestial events for oppositions of planets" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::OppositionsGenerator
+        .new(start_date, end_date)
+
+      expect { generator.generate }
+        .to change { CelestialEvent.count }.from(0).to(4)
+    end
+
+    it "creates opposition kind of celestial events" do
+      start_date = Time.utc(2026, 1, 1)
+      end_date = Time.utc(2027, 1, 1)
+
+      generator = CelestialEvents::OppositionsGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.pluck(:kind).uniq)
+        .to contain_exactly(CelestialEvent::OPPOSITION)
+    end
+
+    it "sets the peak_tt of the celestial events to relevant values" do
+      start_date = Time.utc(2026, 1, 1)
+      start_tt = Astronoby::Instant.from_time(start_date).tt
+      end_date = Time.utc(2027, 1, 1)
+      end_tt = Astronoby::Instant.from_time(end_date).tt
+
+      generator = CelestialEvents::OppositionsGenerator
+        .new(start_date, end_date)
+
+      generator.generate
+
+      expect(CelestialEvent.pluck(:peak_tt))
+        .to all(be >= start_tt)
+        .and all(be <= end_tt)
+    end
+  end
+end

--- a/spec/models/celestial_events/planetary_conjunctions_generator_spec.rb
+++ b/spec/models/celestial_events/planetary_conjunctions_generator_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe CelestialEvents::PlanetaryConjunctionsGenerator, type: :model do
+  describe "#generate" do
+    it "records both planets of the pairing" do
+      start_date = Time.utc(2026, 11, 1)
+      end_date = Time.utc(2026, 12, 1)
+
+      CelestialEvents::PlanetaryConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      event = CelestialEvent.chronological.first
+
+      expect(event.primary_body).to eq("Mars")
+      expect(event.secondary_body).to eq("Jupiter")
+    end
+
+    it "skips a pairing that is too far apart to look close" do
+      start_date = Time.utc(2026, 2, 1)
+      end_date = Time.utc(2026, 2, 20)
+
+      CelestialEvents::PlanetaryConjunctionsGenerator
+        .new(start_date, end_date)
+        .generate
+
+      expect(CelestialEvent.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AlmanacController, type: :request do
+  describe "GET /almanac" do
+    it "returns a successful response" do
+      travel_to Time.utc(2025, 8, 30) do
+        get almanac_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    it "tracks the page view" do
+      travel_to Time.utc(2026, 8, 30) do
+        expect(Appsignal).to(
+          receive(:increment_counter)
+            .with("page_view", 1, page: "almanac")
+        )
+
+        get almanac_path
+      end
+    end
+  end
+end

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -93,10 +93,16 @@ RSpec.describe AlmanacController, type: :request do
 
     it "shows lunar apsides in the month header rather than the timeline" do
       travel_to Time.utc(2026, 8, 30) do
-        create(:celestial_event, kind: CelestialEvent::FULL_MOON,
-          peak: Time.utc(2026, 11, 4, 12))
-        create(:celestial_event, kind: CelestialEvent::MOON_PERIGEE,
-          peak: Time.utc(2026, 11, 9, 12))
+        create(
+          :celestial_event,
+          kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 11, 4, 12)
+        )
+        create(
+          :celestial_event,
+          kind: CelestialEvent::MOON_PERIGEE,
+          peak: Time.utc(2026, 11, 9, 12)
+        )
 
         get almanac_path
 
@@ -104,6 +110,26 @@ RSpec.describe AlmanacController, type: :request do
         expect(response.body).to include("Moon distance in November 2026")
         expect(response.body).not_to include("The Moon at perigee")
         expect(response.body).not_to include('class="almanac-timeline"')
+      end
+    end
+
+    it "shows a month whose only upcoming event is a lunar apsis" do
+      travel_to Time.utc(2026, 10, 27) do
+        create(
+          :celestial_event,
+          kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 10, 26, 12)
+        )
+        create(
+          :celestial_event,
+          kind: CelestialEvent::MOON_APOGEE,
+          peak: Time.utc(2026, 10, 30, 12)
+        )
+
+        get almanac_path
+
+        expect(response.body).to include("October 2026")
+        expect(response.body).to include("almanac-apsis-strip")
       end
     end
 

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -91,6 +91,22 @@ RSpec.describe AlmanacController, type: :request do
       end
     end
 
+    it "shows lunar apsides in the month header rather than the timeline" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(:celestial_event, kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 11, 4, 12))
+        create(:celestial_event, kind: CelestialEvent::MOON_PERIGEE,
+          peak: Time.utc(2026, 11, 9, 12))
+
+        get almanac_path
+
+        expect(response.body).to include("almanac-apsis-strip")
+        expect(response.body).to include("Moon distance in November 2026")
+        expect(response.body).not_to include("The Moon at perigee")
+        expect(response.body).not_to include('class="almanac-timeline"')
+      end
+    end
+
     it "renders an empty state when no event is upcoming" do
       travel_to Time.utc(2026, 8, 30) do
         create(:celestial_event, peak: Time.utc(2020, 1, 1))

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -133,6 +133,30 @@ RSpec.describe AlmanacController, type: :request do
       end
     end
 
+    it "counts everything it shows, not only the timeline" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(:celestial_event, kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 11, 4, 12))
+        create(:celestial_event, kind: CelestialEvent::MOON_APOGEE,
+          peak: Time.utc(2026, 11, 9, 12))
+
+        get almanac_path
+
+        expect(response.body).to include("2 events")
+      end
+    end
+
+    it "shows the last month of the period whole" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(:celestial_event, kind: CelestialEvent::OPPOSITION,
+          primary_body: "Mars", peak: Time.utc(2027, 8, 31, 12))
+
+        get almanac_path
+
+        expect(response.body).to include("Mars at opposition")
+      end
+    end
+
     it "renders an empty state when no event is upcoming" do
       travel_to Time.utc(2026, 8, 30) do
         create(:celestial_event, peak: Time.utc(2020, 1, 1))

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -12,6 +12,39 @@ RSpec.describe AlmanacController, type: :request do
       end
     end
 
+    it "lists the events falling within the lookahead window" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: "Mars",
+          peak: Time.utc(2026, 11, 4, 21, 30)
+        )
+        create(
+          :celestial_event,
+          kind: CelestialEvent::OPPOSITION,
+          primary_body: "Saturn",
+          peak: Time.utc(2028, 3, 1)
+        )
+
+        get almanac_path
+
+        expect(response.body).to include("Mars at opposition")
+        expect(response.body).to include("November 2026")
+        expect(response.body).not_to include("Saturn at opposition")
+      end
+    end
+
+    it "renders an empty state when no event is upcoming" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(:celestial_event, peak: Time.utc(2020, 1, 1))
+
+        get almanac_path
+
+        expect(response.body).to include("No events on the horizon")
+      end
+    end
+
     it "tracks the page view" do
       travel_to Time.utc(2026, 8, 30) do
         expect(Appsignal).to(

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -35,6 +35,33 @@ RSpec.describe AlmanacController, type: :request do
       end
     end
 
+    it "shows moon phases in the month strip rather than the timeline" do
+      travel_to Time.utc(2026, 8, 30) do
+        create(:celestial_event, kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 11, 4, 12))
+
+        get almanac_path
+
+        expect(response.body).to include("almanac-phase-strip")
+        expect(response.body).to include("Moon phases in November 2026")
+        expect(response.body).not_to include('class="almanac-timeline"')
+      end
+    end
+
+    it "shows a whole month of phases even mid-month" do
+      travel_to Time.utc(2026, 9, 12) do
+        early = create(:celestial_event, kind: CelestialEvent::NEW_MOON,
+          peak: Time.utc(2026, 9, 4, 12))
+        late = create(:celestial_event, kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 9, 26, 12))
+
+        get almanac_path
+
+        expect(response.body).to include(early.peak_at.in_time_zone.iso8601)
+        expect(response.body).to include(late.peak_at.in_time_zone.iso8601)
+      end
+    end
+
     it "renders an empty state when no event is upcoming" do
       travel_to Time.utc(2026, 8, 30) do
         create(:celestial_event, peak: Time.utc(2020, 1, 1))

--- a/spec/requests/almanac_spec.rb
+++ b/spec/requests/almanac_spec.rb
@@ -37,8 +37,11 @@ RSpec.describe AlmanacController, type: :request do
 
     it "shows moon phases in the month strip rather than the timeline" do
       travel_to Time.utc(2026, 8, 30) do
-        create(:celestial_event, kind: CelestialEvent::FULL_MOON,
-          peak: Time.utc(2026, 11, 4, 12))
+        create(
+          :celestial_event,
+          kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 11, 4, 12)
+        )
 
         get almanac_path
 
@@ -50,15 +53,41 @@ RSpec.describe AlmanacController, type: :request do
 
     it "shows a whole month of phases even mid-month" do
       travel_to Time.utc(2026, 9, 12) do
-        early = create(:celestial_event, kind: CelestialEvent::NEW_MOON,
-          peak: Time.utc(2026, 9, 4, 12))
-        late = create(:celestial_event, kind: CelestialEvent::FULL_MOON,
-          peak: Time.utc(2026, 9, 26, 12))
+        early = create(
+          :celestial_event,
+          kind: CelestialEvent::NEW_MOON,
+          peak: Time.utc(2026, 9, 4, 12)
+        )
+        late = create(
+          :celestial_event,
+          kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 9, 26, 12)
+        )
 
         get almanac_path
 
         expect(response.body).to include(early.peak_at.in_time_zone.iso8601)
         expect(response.body).to include(late.peak_at.in_time_zone.iso8601)
+      end
+    end
+
+    it "drops a month whose events and phases have all passed" do
+      travel_to Time.utc(2026, 8, 31, 12) do
+        create(
+          :celestial_event,
+          kind: CelestialEvent::FULL_MOON,
+          peak: Time.utc(2026, 8, 28, 12)
+        )
+        create(
+          :celestial_event,
+          kind: CelestialEvent::NEW_MOON,
+          peak: Time.utc(2026, 9, 11, 12)
+        )
+
+        get almanac_path
+
+        expect(response.body).not_to include("August 2026")
+        expect(response.body).to include("September 2026")
       end
     end
 

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This adds a new Almanac page, listing the celestial events coming up over the next twelve months.

Events are precomputed with Astronoby and stored in a new `celestial_events` table, with one generator per kind: equinoxes and solstices, Moon phases, lunar eclipses, oppositions, greatest elongations, Moon and Earth orbital extremes, and conjunctions.

Astronoby only computes conjunctions with the Sun, so Moon-planet and planet-planet ones are found here by looking for minima of the angular separation between two bodies. A minimum is used rather than a longitude crossing, because two bodies can come close and separate again without one ever overtaking the other. Each conjunction generator keeps only what is worth a line: naked-eye planets, far enough from the Sun, and close enough together.

The Moon reaches a phase or an orbital extreme about seventy times a year, which is far more than everything else combined. Instead of flooding the timeline, they are displayed in the month header, next to its label.

Future improvements:
- Solar eclipses (not supported by Astronoby yet)
- Meteor shower peaks
- Store the separation of a conjunction, to display it on the event
